### PR TITLE
feat: LocalSaveEditorWindow 刷新・テスト追加

### DIFF
--- a/Assets/Editor/Tests/LocalSave/LocalSaveTest.cs
+++ b/Assets/Editor/Tests/LocalSave/LocalSaveTest.cs
@@ -1,20 +1,27 @@
 using NUnit.Framework;
 using UnityEngine;
+using UniLab.Persistence;
 
 namespace UniLab.Tests.EditMode.LocalSave
 {
     public class LocalSaveTests
     {
-#if false // ファイルの書き込み読み込みが発生するので、このテストはコメントアウト。書き換えるときに true に変更してアクセスすること
         [SetUp]
-        public void Setup()
+        public void SetUp()
         {
-            // 毎テスト前にクリア
             PlayerPrefs.DeleteAll();
+            PlayerPrefs.Save();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            PlayerPrefs.DeleteAll();
+            PlayerPrefs.Save();
         }
 
         [Test]
-        public void SaveAndLoadTest()
+        public void SaveAndLoad_ReturnsEquivalentData()
         {
             var data = new TestData { Value = 123, Name = "TestUser" };
             LocalSave.Save(data);
@@ -26,53 +33,123 @@ namespace UniLab.Tests.EditMode.LocalSave
         }
 
         [Test]
-        public void DeleteTest()
+        public void Delete_LoadReturnsDefaultValue()
         {
             var data = new TestData { Value = 456, Name = "ToDelete" };
             LocalSave.Save(data);
             LocalSave.Delete<TestData>();
+
             var loaded = LocalSave.Load<TestData>();
+
             Assert.AreNotEqual(data.Value, loaded.Value);
             Assert.AreNotEqual(data.Name, loaded.Name);
         }
 
         [Test]
-        public void DeleteAllTest()
+        public void DeleteAll_LoadReturnsDefaultValue()
         {
             var data = new TestData { Value = 789, Name = "AllGone" };
             LocalSave.Save(data);
             LocalSave.DeleteAll();
+
             var loaded = LocalSave.Load<TestData>();
+
             Assert.AreNotEqual(data.Value, loaded.Value);
             Assert.AreNotEqual(data.Name, loaded.Name);
         }
 
         [Test]
-        public void LoadDefaultValueWhenNotSaved()
+        public void Load_WhenNeverSaved_ReturnsDefaultValue()
         {
             var loaded = LocalSave.Load<TestData>();
+
             Assert.AreEqual(0, loaded.Value);
             Assert.IsNull(loaded.Name);
         }
-    }
 
-    [System.Serializable]
-    public class TestData
-    {
-        public int Value;
-        public string Name;
+        // --- Editor key registry tests ---
 
-        public override bool Equals(object obj)
+        [Test]
+        public void Save_RegistersKeyInEditorAndPlayerPrefsHasKey()
         {
-            if (obj is TestData other)
-                return Value == other.Value && Name == other.Name;
-            return false;
+            var data = new SampleData { Score = 10 };
+            LocalSave.Save(data);
+
+            var key = typeof(SampleData).FullName;
+            var registeredKeys = LocalSave.GetAllKeysInEditor();
+
+            Assert.IsTrue(registeredKeys.Contains(key), "Key should be present in GetAllKeysInEditor().");
+            Assert.IsTrue(PlayerPrefs.HasKey(key), "PlayerPrefs should have the key after Save.");
         }
 
-        public override int GetHashCode()
+        [Test]
+        public void DeleteEditorOnly_RemovesKeyFromRegistryAndPlayerPrefs()
         {
-            return Value.GetHashCode() ^ Name.GetHashCode();
+            var data = new SampleData { Score = 20 };
+            LocalSave.Save(data);
+
+            var key = typeof(SampleData).FullName;
+            LocalSave.DeleteEditorOnly(key);
+
+            var registeredKeys = LocalSave.GetAllKeysInEditor();
+
+            Assert.IsFalse(registeredKeys.Contains(key), "Key should be removed from GetAllKeysInEditor() after DeleteEditorOnly.");
+            Assert.IsFalse(PlayerPrefs.HasKey(key), "PlayerPrefs should not have the key after DeleteEditorOnly.");
         }
-#endif
+
+        [Test]
+        public void DirectPlayerPrefsDeleteKey_LeavesKeyInRegistryButNotInPlayerPrefs()
+        {
+            // This scenario represents the "Not saved" state shown in LocalSaveEditorWindow Section 2.
+            // The registry retains the key, but PlayerPrefs no longer has the actual value.
+            var data = new SampleData { Score = 30 };
+            LocalSave.Save(data);
+
+            var key = typeof(SampleData).FullName;
+            PlayerPrefs.DeleteKey(key);
+            PlayerPrefs.Save();
+
+            var registeredKeys = LocalSave.GetAllKeysInEditor();
+
+            Assert.IsTrue(registeredKeys.Contains(key), "Key should still be present in registry after direct PlayerPrefs.DeleteKey.");
+            Assert.IsFalse(PlayerPrefs.HasKey(key), "PlayerPrefs should not have the key after direct deletion.");
+        }
+
+        [Test]
+        public void DeleteAll_ClearsRegistryAndAllPlayerPrefsKeys()
+        {
+            LocalSave.Save(new SampleData { Score = 1 });
+            LocalSave.Save(new SampleData2 { Name = "Alice" });
+
+            var key1 = typeof(SampleData).FullName;
+            var key2 = typeof(SampleData2).FullName;
+
+            LocalSave.DeleteAll();
+
+            var registeredKeys = LocalSave.GetAllKeysInEditor();
+
+            Assert.IsEmpty(registeredKeys, "Registry should be empty after DeleteAll.");
+            Assert.IsFalse(PlayerPrefs.HasKey(key1), "PlayerPrefs should not have key1 after DeleteAll.");
+            Assert.IsFalse(PlayerPrefs.HasKey(key2), "PlayerPrefs should not have key2 after DeleteAll.");
+        }
+
+        [System.Serializable]
+        public class TestData
+        {
+            public int Value;
+            public string Name;
+        }
+
+        [System.Serializable]
+        private sealed class SampleData
+        {
+            public int Score;
+        }
+
+        [System.Serializable]
+        private sealed class SampleData2
+        {
+            public string Name;
+        }
     }
 }

--- a/Assets/UniLab/Persistence/Editor/LocalSaveEditorWindow.cs
+++ b/Assets/UniLab/Persistence/Editor/LocalSaveEditorWindow.cs
@@ -4,19 +4,30 @@ using UnityEngine;
 
 namespace UniLab.Persistence.Editor
 {
+    /// <summary>
+    /// Editor window for managing LocalSave keys and PlayerPrefs data.
+    /// </summary>
     public sealed class LocalSaveEditorWindow : EditorWindow
     {
-        private Vector2 _scroll;
-        private List<string> _keys;
+        private const float StatusLabelWidth = 70f;
+        private const float DeleteButtonWidth = 60f;
+        private const float RowSpacing = 2f;
+        private static readonly Vector2 MinWindowSize = new Vector2(480f, 600f);
 
+        private List<string> _keys = new List<string>();
+        private Vector2 _scrollPosition;
+        private string _directDeleteKey = string.Empty;
+
+        /// <summary>Opens the LocalSave Manager window.</summary>
         [MenuItem("UniLab/LocalSave/SaveDataManage")]
         public static void Open()
         {
-            GetWindow<LocalSaveEditorWindow>("SaveDataManage");
+            GetWindow<LocalSaveEditorWindow>("LocalSave Manager");
         }
 
         private void OnEnable()
         {
+            minSize = MinWindowSize;
             RefreshKeys();
         }
 
@@ -27,40 +38,102 @@ namespace UniLab.Persistence.Editor
 
         private void OnGUI()
         {
-            if (GUILayout.Button("Refresh"))
-            {
-                RefreshKeys();
-            }
-
-            if (GUILayout.Button("Delete All"))
-            {
-                if (EditorUtility.DisplayDialog("Confirm", "全てのローカルのセーブデータを削除します。よろしいですか？", "はい", "キャンセル"))
-                {
-                    LocalSave.DeleteAll();
-                    RefreshKeys();
-                }
-            }
-
+            EditorGUILayout.HelpBox("Manages registered LocalSave keys and allows direct PlayerPrefs deletion.", MessageType.Info);
             EditorGUILayout.Space();
 
-            _scroll = EditorGUILayout.BeginScrollView(_scroll);
+            DrawDeleteAllSection();
+            EditorGUILayout.Space();
 
-            foreach (var key in _keys.ToArray())
+            DrawDirectKeyDeletionSection();
+            EditorGUILayout.Space();
+
+            DrawRegisteredKeysSection();
+        }
+
+        private void DrawDeleteAllSection()
+        {
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
-                EditorGUILayout.BeginHorizontal();
-                EditorGUILayout.LabelField(key);
-                if (GUILayout.Button("Delete", GUILayout.Width(60)))
+                EditorGUILayout.LabelField("Delete All", EditorStyles.boldLabel);
+                if (GUILayout.Button("Delete All LocalSave Data"))
                 {
-                    LocalSave.DeleteEditorOnly(key);
-                    RefreshKeys();
-                    EditorGUILayout.EndHorizontal();
-                    break;
+                    if (EditorUtility.DisplayDialog("Confirm", "Delete all LocalSave data?", "Delete", "Cancel"))
+                    {
+                        LocalSave.DeleteAll();
+                        RefreshKeys();
+                    }
+                }
+            }
+        }
+
+        private void DrawDirectKeyDeletionSection()
+        {
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+            {
+                EditorGUILayout.LabelField("Direct Key Deletion", EditorStyles.boldLabel);
+                _directDeleteKey = EditorGUILayout.TextField("Key", _directDeleteKey);
+
+                using (new EditorGUI.DisabledScope(string.IsNullOrWhiteSpace(_directDeleteKey)))
+                {
+                    if (GUILayout.Button("Delete Key"))
+                    {
+                        if (EditorUtility.DisplayDialog("Confirm", $"Delete PlayerPrefs key \"{_directDeleteKey}\"?", "Delete", "Cancel"))
+                        {
+                            PlayerPrefs.DeleteKey(_directDeleteKey);
+                            PlayerPrefs.Save();
+                        }
+                    }
+                }
+            }
+        }
+
+        private void DrawRegisteredKeysSection()
+        {
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+            {
+                using (new EditorGUILayout.HorizontalScope())
+                {
+                    EditorGUILayout.LabelField("Registered Keys", EditorStyles.boldLabel);
+                    if (GUILayout.Button("Refresh", GUILayout.Width(70f)))
+                    {
+                        RefreshKeys();
+                    }
                 }
 
-                EditorGUILayout.EndHorizontal();
+                _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
+                foreach (var key in _keys.ToArray())
+                {
+                    DrawKeyRow(key);
+                }
+                EditorGUILayout.EndScrollView();
             }
+        }
 
-            EditorGUILayout.EndScrollView();
+        private void DrawKeyRow(string key)
+        {
+            var lineHeight = EditorGUIUtility.singleLineHeight;
+            var rowRect = EditorGUILayout.GetControlRect(false, lineHeight + RowSpacing);
+
+            var keyRect = new Rect(rowRect.x, rowRect.y, rowRect.width - StatusLabelWidth - DeleteButtonWidth - 8f, lineHeight);
+            var statusRect = new Rect(keyRect.xMax + 4f, rowRect.y, StatusLabelWidth, lineHeight);
+            var deleteRect = new Rect(statusRect.xMax + 4f, rowRect.y, DeleteButtonWidth, lineHeight);
+
+            EditorGUI.SelectableLabel(keyRect, key);
+
+            var isSaved = PlayerPrefs.HasKey(key);
+            EditorGUI.LabelField(statusRect, isSaved ? "Saved" : "Not saved");
+
+            using (new EditorGUI.DisabledScope(!isSaved))
+            {
+                if (GUI.Button(deleteRect, "Delete"))
+                {
+                    if (EditorUtility.DisplayDialog("Confirm", $"Delete key \"{key}\"?", "Delete", "Cancel"))
+                    {
+                        LocalSave.DeleteEditorOnly(key);
+                        RefreshKeys();
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- `LocalSaveEditorWindow` を3セクション構成に刷新（全削除 / キー直接削除 / 登録済みキー一覧）
- 直接 PlayerPrefs キー削除セクションを新規追加（LocalSave 未登録キーも対象）
- 各キー行に "Saved" / "Not saved" ステータス表示・SelectableLabel でコピー可能に
- `LocalSaveTest` を有効化し、エディタキー登録シナリオのテスト4本を追加

## Test plan

- [ ] Unity Editor で `UniLab/LocalSave/SaveDataManage` を開いて3セクションが表示されること
- [ ] Delete All で確認ダイアログが出て全削除されること
- [ ] Direct Key Deletion でキー入力→削除が動作すること
- [ ] Registered Keys の各行に Saved / Not saved が表示されること
- [ ] EditMode テストがすべて Pass すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)