### PR TITLE
feat: サンプルシーンをメニュー→機能詳細ナビゲーション構成に刷新

### DIFF
--- a/Assets/UniLab/Animation.meta
+++ b/Assets/UniLab/Animation.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e67094aea3bab4b76b604766204bcada
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Animation/AnimationPlayer.cs.meta
+++ b/Assets/UniLab/Animation/AnimationPlayer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 017db9d3f3dad4eb4b474f6e37603ab6

--- a/Assets/UniLab/Audio.meta
+++ b/Assets/UniLab/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3df8216fa436e48b18aec2192743aa96
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Audio/SoundPlayManager.cs.meta
+++ b/Assets/UniLab/Audio/SoundPlayManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2d5292925f6964a2f948ac8b35e8042f

--- a/Assets/UniLab/Banner.meta
+++ b/Assets/UniLab/Banner.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9d49ad82285ec40f593bd6ffd028ed4b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Banner/BannerCellBase.cs.meta
+++ b/Assets/UniLab/Banner/BannerCellBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 53e3e6e721bd3478bbb0c1b14533e084

--- a/Assets/UniLab/Banner/BannerViewBase.cs.meta
+++ b/Assets/UniLab/Banner/BannerViewBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48161865ca15e40c8bcd529d245b88bf

--- a/Assets/UniLab/Common/Sound.meta
+++ b/Assets/UniLab/Common/Sound.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80ccbd301cb64651b286d7c807853923
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Indicator.meta
+++ b/Assets/UniLab/Indicator.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 62fc15fb3acf541f0809df961f9a2467
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Indicator/IndicatorCellBase.cs.meta
+++ b/Assets/UniLab/Indicator/IndicatorCellBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2321ca5b7784d4c2980e6d009e1caa64

--- a/Assets/UniLab/Indicator/IndicatorManagerBase.cs.meta
+++ b/Assets/UniLab/Indicator/IndicatorManagerBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4dd0c9f98e09434cb12faba95ebca65

--- a/Assets/UniLab/Indicator/UniLabIndicatorManager.cs.meta
+++ b/Assets/UniLab/Indicator/UniLabIndicatorManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03b451a4eb95943e786d1a968c896b34

--- a/Assets/UniLab/Input.meta
+++ b/Assets/UniLab/Input.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6483e388841294b66b72f1e9a081d6a1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Input/BackKeyInputManager.cs.meta
+++ b/Assets/UniLab/Input/BackKeyInputManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5449234e5dd0f448fb8671aad258b7ae

--- a/Assets/UniLab/Localization.meta
+++ b/Assets/UniLab/Localization.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01c7a776f25a24d5ebc3ba309fe33a8c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Localization/Editor.meta
+++ b/Assets/UniLab/Localization/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 897e2f979a5f84a0c90e1c42a29301ff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Localization/Editor/LanguageSelectorWindow.cs.meta
+++ b/Assets/UniLab/Localization/Editor/LanguageSelectorWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6a0d8f27688614d638acd5eb925c3ae4

--- a/Assets/UniLab/Localization/Editor/LocalizationAssetPostprocessor.cs.meta
+++ b/Assets/UniLab/Localization/Editor/LocalizationAssetPostprocessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f29c8b7eb2cbd417da5dffb6bd133bef

--- a/Assets/UniLab/Localization/Editor/LocalizationImporterWindow.cs.meta
+++ b/Assets/UniLab/Localization/Editor/LocalizationImporterWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0dcef9a04e05e446b90eedb92d03ce7c

--- a/Assets/UniLab/Localization/Editor/LocalizationKeyDropdownDrawer.cs.meta
+++ b/Assets/UniLab/Localization/Editor/LocalizationKeyDropdownDrawer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1eb82d6873e554d268a2a28f4b595c3f

--- a/Assets/UniLab/Localization/Editor/LocalizedTextUpdater.cs.meta
+++ b/Assets/UniLab/Localization/Editor/LocalizedTextUpdater.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c113eb3a46a26495abf3f078568a0043

--- a/Assets/UniLab/Localization/Runtime.meta
+++ b/Assets/UniLab/Localization/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6f7ce13c7647242329270cf5adb49f39
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Localization/Runtime/KeyHash.cs.meta
+++ b/Assets/UniLab/Localization/Runtime/KeyHash.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fed91bf1f609f442eb1d63a42966182d

--- a/Assets/UniLab/Localization/Runtime/LocalizationData.cs.meta
+++ b/Assets/UniLab/Localization/Runtime/LocalizationData.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 6d091e54686104d87b97b24693618815

--- a/Assets/UniLab/Localization/Runtime/LocalizationEntry.cs.meta
+++ b/Assets/UniLab/Localization/Runtime/LocalizationEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f30c259627d2349459b35406087e9b70

--- a/Assets/UniLab/Localization/Runtime/LocalizedText.cs.meta
+++ b/Assets/UniLab/Localization/Runtime/LocalizedText.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cf74327be5b11491cbdd23f5f368eddd

--- a/Assets/UniLab/Localization/Runtime/TextManager.cs.meta
+++ b/Assets/UniLab/Localization/Runtime/TextManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3208c23ca049e4bb0b4b4eeeaa1bcc29

--- a/Assets/UniLab/MasterData.meta
+++ b/Assets/UniLab/MasterData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a191c6bdf0afa452ab2094592928eeff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/MasterData/Editor.meta
+++ b/Assets/UniLab/MasterData/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5b81beaf00d6943239e7d5231e37b4f9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/MasterData/Editor/MasterLocalViewer.cs.meta
+++ b/Assets/UniLab/MasterData/Editor/MasterLocalViewer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ff8e0d907da445519030ae0ce7c2762

--- a/Assets/UniLab/MasterData/MasterBase.cs.meta
+++ b/Assets/UniLab/MasterData/MasterBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 96c503d2b1ae3467ea8ac7ff1f70af77

--- a/Assets/UniLab/MasterData/MasterCalculator.cs.meta
+++ b/Assets/UniLab/MasterData/MasterCalculator.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 047ec38f491b34cb9b3bfded9a6d82d6

--- a/Assets/UniLab/MasterData/MasterCatalog.cs.meta
+++ b/Assets/UniLab/MasterData/MasterCatalog.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71ab7ece907e447ceb25ca9799831b08

--- a/Assets/UniLab/MasterData/MasterManager.cs.meta
+++ b/Assets/UniLab/MasterData/MasterManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: aea022b7f1fe74a9d9be4b4d181790c9

--- a/Assets/UniLab/Notification.meta
+++ b/Assets/UniLab/Notification.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc6ff988d86bc4cb48a7231bb7454be3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Notification/MobileLocalNotification.cs.meta
+++ b/Assets/UniLab/Notification/MobileLocalNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 05875108ebc4d42858fa98def49dd449

--- a/Assets/UniLab/Notification/NotificationPermissionStatus.cs.meta
+++ b/Assets/UniLab/Notification/NotificationPermissionStatus.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1d5c972cab17b4d5ea539ddccca489e4

--- a/Assets/UniLab/Notification/Platform.meta
+++ b/Assets/UniLab/Notification/Platform.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2db8633b7e87f4832a042ebaf06fff48
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Notification/Platform/AndroidMobileNotification.cs.meta
+++ b/Assets/UniLab/Notification/Platform/AndroidMobileNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fa11b1c05dce64ad783f73c1362f16ef

--- a/Assets/UniLab/Notification/Platform/AndroidNotificationInformation.cs.meta
+++ b/Assets/UniLab/Notification/Platform/AndroidNotificationInformation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 900503db91b394adab17375f31061753

--- a/Assets/UniLab/Notification/Platform/IOSMobileNotification.cs.meta
+++ b/Assets/UniLab/Notification/Platform/IOSMobileNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fdf482cc85fb34a2a8d32f97902de5d6

--- a/Assets/UniLab/Notification/Platform/Interface.meta
+++ b/Assets/UniLab/Notification/Platform/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5da8d35f45bcb49f4a73a39b0d28521f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Notification/Platform/Interface/ILocalMobileNotification.cs.meta
+++ b/Assets/UniLab/Notification/Platform/Interface/ILocalMobileNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7e827027351304ed89bcf661aa1f283c

--- a/Assets/UniLab/Notification/Platform/StandaloneNotification.cs.meta
+++ b/Assets/UniLab/Notification/Platform/StandaloneNotification.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae0c8bf2cf2414ff4bccc9ac034487fb

--- a/Assets/UniLab/Persistence.meta
+++ b/Assets/UniLab/Persistence.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 18476581513864929a9e64d8bd83a1a8
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Persistence/Editor.meta
+++ b/Assets/UniLab/Persistence/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d4a11c33e8c0448bbb3492810d6d61a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Persistence/Editor/LocalSaveEditor.asmdef.meta
+++ b/Assets/UniLab/Persistence/Editor/LocalSaveEditor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8c2c2acbea2764e94853aca0c4304365
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Persistence/Editor/LocalSaveEditorWindow.cs.meta
+++ b/Assets/UniLab/Persistence/Editor/LocalSaveEditorWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9659533a4de714bd0b9800c94a3a4fec

--- a/Assets/UniLab/Persistence/EncryptedLocalStorage.cs.meta
+++ b/Assets/UniLab/Persistence/EncryptedLocalStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eef66c6f65288412fb1bcbc4ddfa7ef7

--- a/Assets/UniLab/Persistence/Interface.meta
+++ b/Assets/UniLab/Persistence/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 17696129f6d22448a8240f97bb091067
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Persistence/Interface/ILocalStorage.cs.meta
+++ b/Assets/UniLab/Persistence/Interface/ILocalStorage.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b05927151d70145b6a0d120247fb2a56

--- a/Assets/UniLab/Persistence/LocalSave.cs.meta
+++ b/Assets/UniLab/Persistence/LocalSave.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86cc680ad8ebc4a9e88908a2b65a8731

--- a/Assets/UniLab/Persistence/PlayerPrefsWrapper.cs.meta
+++ b/Assets/UniLab/Persistence/PlayerPrefsWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 984366c99ae87476c9112835d65f5613

--- a/Assets/UniLab/Sample/UniLabSampleScene.cs
+++ b/Assets/UniLab/Sample/UniLabSampleScene.cs
@@ -457,9 +457,6 @@ public sealed class UniLabSampleScene : MonoBehaviour
         var bg = CreatePanel(canvasGo.transform, "BG", new Color(0.09f, 0.09f, 0.11f));
         SetFullStretch(bg);
 
-        // ----- Header -----
-        BuildHeader(canvasGo.transform);
-
         // ----- Menu panel -----
         BuildMenuPanel(canvasGo.transform);
 
@@ -468,6 +465,9 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
         // ----- Log panel -----
         BuildLogPanel(canvasGo.transform);
+
+        // ----- Header (last = highest sibling index = top of raycast priority) -----
+        BuildHeader(canvasGo.transform);
 
         // Start at menu screen
         ShowMenu();

--- a/Assets/UniLab/Sample/UniLabSampleScene.cs
+++ b/Assets/UniLab/Sample/UniLabSampleScene.cs
@@ -25,7 +25,6 @@ namespace UniLab.Sample
 /// placed in the scene with its Inspector fields wired:
 ///   - ToastManager          : _toastPrefab / _toastRoot
 ///   - LoadingOverlayManager : _overlayRoot
-///   - SoundPlayManager      : _audioMixer / mixer groups
 /// Toggle the matching bool field in this component's Inspector to enable those demos.
 /// All other features work without any additional setup.
 /// </summary>
@@ -37,6 +36,24 @@ public sealed class UniLabSampleScene : MonoBehaviour
     [SerializeField] private bool _hasToastManager = false;
     [SerializeField] private bool _hasLoadingManager = false;
 
+    // ----- Screen state -----
+
+    private enum FeatureId
+    {
+        LocalSave,
+        EncryptedStorage,
+        TextManager,
+        InputBlock,
+        Network,
+        OfflineQueue,
+        Grid,
+        UniLabButton,
+        AnimationPlayer,
+        Toast,
+        Loading,
+        BackKey,
+    }
+
     // ----- Runtime UI -----
 
     private Text _logText;
@@ -44,9 +61,17 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private const int MaxLogLines = 14;
     private Font _font;
 
+    private GameObject _menuPanel;
+    private GameObject _featurePanel;
+    private RectTransform _featurePanelContent;
+    private GameObject _backButton;
+
     // ----- Disposables -----
 
     private readonly CompositeDisposable _disposables = new();
+
+    // Per-feature subscriptions (e.g. UniLabButton) — cleared on each ShowFeature call
+    private readonly CompositeDisposable _featureDisposables = new();
 
     // ----- Feature state -----
 
@@ -70,6 +95,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void OnDestroy()
     {
         _inputBlockHandle?.Dispose();
+        _featureDisposables.Dispose();
         _disposables.Dispose();
         _networkObservable?.Dispose();
     }
@@ -97,6 +123,51 @@ public sealed class UniLabSampleScene : MonoBehaviour
                 .Subscribe(_ => Log("[BackKey] Back pressed")));
 
         Log("UniLab Sample ready. Tap any button to demo a feature.");
+    }
+
+    // =========================================================
+    // Navigation
+    // =========================================================
+
+    private void ShowMenu()
+    {
+        _menuPanel.SetActive(true);
+        _featurePanel.SetActive(false);
+        _backButton.SetActive(false);
+    }
+
+    private void ShowFeature(FeatureId id)
+    {
+        // Release previous feature-specific subscriptions before rebuilding content
+        _featureDisposables.Clear();
+
+        _menuPanel.SetActive(false);
+        _featurePanel.SetActive(true);
+        _backButton.SetActive(true);
+
+        // Clear previous content
+        foreach (Transform child in _featurePanelContent)
+        {
+            Destroy(child.gameObject);
+        }
+        _gridContainer = null;
+        _gridChildCount = 0;
+
+        switch (id)
+        {
+            case FeatureId.LocalSave:          BuildFeatureContent_LocalSave(_featurePanelContent);         break;
+            case FeatureId.EncryptedStorage:   BuildFeatureContent_EncryptedStorage(_featurePanelContent);  break;
+            case FeatureId.TextManager:        BuildFeatureContent_TextManager(_featurePanelContent);        break;
+            case FeatureId.InputBlock:         BuildFeatureContent_InputBlock(_featurePanelContent);         break;
+            case FeatureId.Network:            BuildFeatureContent_Network(_featurePanelContent);            break;
+            case FeatureId.OfflineQueue:       BuildFeatureContent_OfflineQueue(_featurePanelContent);       break;
+            case FeatureId.Grid:               BuildFeatureContent_Grid(_featurePanelContent);               break;
+            case FeatureId.UniLabButton:       BuildFeatureContent_UniLabButton(_featurePanelContent);       break;
+            case FeatureId.AnimationPlayer:    BuildFeatureContent_AnimationPlayer(_featurePanelContent);    break;
+            case FeatureId.Toast:              BuildFeatureContent_Toast(_featurePanelContent);              break;
+            case FeatureId.Loading:            BuildFeatureContent_Loading(_featurePanelContent);            break;
+            case FeatureId.BackKey:            BuildFeatureContent_BackKey(_featurePanelContent);            break;
+        }
     }
 
     // =========================================================
@@ -387,36 +458,139 @@ public sealed class UniLabSampleScene : MonoBehaviour
         SetFullStretch(bg);
 
         // ----- Header -----
-        var header = CreatePanel(canvasGo.transform, "Header", new Color(0.06f, 0.06f, 0.08f));
-        SetAnchoredLayout(header, new Vector2(0f, 0.94f), Vector2.one);
-        CreateLabel(header, "UniLab Feature Sample", 26, TextAnchor.MiddleCenter, Color.white);
+        BuildHeader(canvasGo.transform);
 
-        // ----- Scroll area (main demos) -----
-        var scroll = BuildScrollRect(canvasGo.transform, new Vector2(0f, 0.22f), new Vector2(1f, 0.94f));
-        var content = scroll.content;
+        // ----- Menu panel -----
+        BuildMenuPanel(canvasGo.transform);
 
-        BuildSectionLocalSave(content);
-        BuildSectionEncryptedStorage(content);
-        BuildSectionTextManager(content);
-        BuildSectionInputBlock(content);
-        BuildSectionNetwork(content);
-        BuildSectionOfflineQueue(content);
-        BuildSectionGrid(content);
-        BuildSectionUniLabButton(content);
-        BuildSectionAnimationPlayer(content);
-        BuildSectionToast(content);
-        BuildSectionLoading(content);
-        BuildSectionBackKey(content);
+        // ----- Feature panel -----
+        BuildFeaturePanel(canvasGo.transform);
 
         // ----- Log panel -----
-        var logPanel = CreatePanel(canvasGo.transform, "LogPanel", new Color(0.04f, 0.04f, 0.06f));
-        SetAnchoredLayout(logPanel, Vector2.zero, new Vector2(1f, 0.22f));
+        BuildLogPanel(canvasGo.transform);
+
+        // Start at menu screen
+        ShowMenu();
+    }
+
+    private void BuildHeader(Transform canvasTransform)
+    {
+        var header = CreatePanel(canvasTransform, "Header", new Color(0.06f, 0.06f, 0.08f));
+        SetAnchoredLayout(header, new Vector2(0f, 0.94f), Vector2.one);
+
+        // Back button — hidden on menu, shown on feature screens
+        var backButtonGo = new GameObject("BackButton", typeof(Image));
+        backButtonGo.transform.SetParent(header, false);
+        backButtonGo.GetComponent<Image>().color = new Color(0.25f, 0.25f, 0.32f);
+
+        var backButtonRect = backButtonGo.GetComponent<RectTransform>();
+        backButtonRect.anchorMin = new Vector2(0f, 0f);
+        backButtonRect.anchorMax = new Vector2(0f, 1f);
+        backButtonRect.pivot = new Vector2(0f, 0.5f);
+        backButtonRect.offsetMin = new Vector2(12f, 8f);
+        backButtonRect.offsetMax = new Vector2(132f, -8f);
+
+        var backButton = backButtonGo.AddComponent<Button>();
+        backButton.targetGraphic = backButtonGo.GetComponent<Image>();
+        backButton.onClick.AddListener(ShowMenu);
+
+        CreateLabel(backButtonRect, "← Back", 24, TextAnchor.MiddleCenter, Color.white);
+
+        _backButton = backButtonGo;
+
+        // Header title
+        CreateLabel(header, "UniLab Feature Sample", 32, TextAnchor.MiddleCenter, Color.white);
+    }
+
+    private void BuildMenuPanel(Transform canvasTransform)
+    {
+        var menuPanelGo = new GameObject("MenuPanel", typeof(RectTransform));
+        menuPanelGo.transform.SetParent(canvasTransform, false);
+        SetAnchoredLayout(menuPanelGo.GetComponent<RectTransform>(), new Vector2(0f, 0.18f), new Vector2(1f, 0.94f));
+        _menuPanel = menuPanelGo;
+
+        var scroll = BuildScrollRect(menuPanelGo.transform, Vector2.zero, Vector2.one);
+        var content = scroll.content;
+
+        foreach (FeatureId featureId in Enum.GetValues(typeof(FeatureId)))
+        {
+            AddMenuButton(content, featureId);
+        }
+    }
+
+    private void AddMenuButton(RectTransform parent, FeatureId featureId)
+    {
+        var buttonGo = new GameObject($"MenuBtn_{featureId}", typeof(Image));
+        buttonGo.transform.SetParent(parent, false);
+        buttonGo.GetComponent<Image>().color = GetCategoryColor(featureId);
+
+        var buttonRect = buttonGo.GetComponent<RectTransform>();
+        buttonRect.anchorMin = new Vector2(0f, 1f);
+        buttonRect.anchorMax = new Vector2(1f, 1f);
+        buttonRect.pivot = new Vector2(0.5f, 1f);
+        buttonRect.sizeDelta = new Vector2(0f, 100f);
+
+        var button = buttonGo.AddComponent<Button>();
+        button.targetGraphic = buttonGo.GetComponent<Image>();
+
+        var colors = button.colors;
+        colors.highlightedColor = new Color(0.9f, 0.9f, 0.9f);
+        colors.pressedColor = new Color(0.6f, 0.6f, 0.6f);
+        button.colors = colors;
+
+        var capturedId = featureId;
+        button.onClick.AddListener(() => ShowFeature(capturedId));
+
+        CreateLabel(buttonRect, featureId.ToString(), 28, TextAnchor.MiddleCenter, Color.white);
+    }
+
+    private static Color GetCategoryColor(FeatureId featureId)
+    {
+        switch (featureId)
+        {
+            case FeatureId.LocalSave:
+            case FeatureId.EncryptedStorage:
+                return new Color(0.22f, 0.35f, 0.55f);
+            case FeatureId.TextManager:
+                return new Color(0.40f, 0.25f, 0.55f);
+            case FeatureId.InputBlock:
+            case FeatureId.UniLabButton:
+            case FeatureId.Toast:
+            case FeatureId.Loading:
+                return new Color(0.55f, 0.35f, 0.15f);
+            case FeatureId.Network:
+            case FeatureId.OfflineQueue:
+                return new Color(0.20f, 0.45f, 0.30f);
+            case FeatureId.Grid:
+            case FeatureId.AnimationPlayer:
+            case FeatureId.BackKey:
+                return new Color(0.20f, 0.40f, 0.45f);
+            default:
+                return new Color(0.22f, 0.22f, 0.28f);
+        }
+    }
+
+    private void BuildFeaturePanel(Transform canvasTransform)
+    {
+        var featurePanelGo = new GameObject("FeaturePanel", typeof(RectTransform));
+        featurePanelGo.transform.SetParent(canvasTransform, false);
+        SetAnchoredLayout(featurePanelGo.GetComponent<RectTransform>(), new Vector2(0f, 0.18f), new Vector2(1f, 0.94f));
+        _featurePanel = featurePanelGo;
+
+        var scroll = BuildScrollRect(featurePanelGo.transform, Vector2.zero, Vector2.one);
+        _featurePanelContent = scroll.content;
+    }
+
+    private void BuildLogPanel(Transform canvasTransform)
+    {
+        var logPanel = CreatePanel(canvasTransform, "LogPanel", new Color(0.04f, 0.04f, 0.06f));
+        SetAnchoredLayout(logPanel, Vector2.zero, new Vector2(1f, 0.18f));
 
         var logGo = new GameObject("LogText");
         logGo.transform.SetParent(logPanel, false);
         _logText = logGo.AddComponent<Text>();
         _logText.font = _font;
-        _logText.fontSize = 13;
+        _logText.fontSize = 20;
         _logText.color = new Color(0.6f, 1f, 0.6f);
         _logText.horizontalOverflow = HorizontalWrapMode.Wrap;
         _logText.verticalOverflow = VerticalWrapMode.Overflow;
@@ -427,64 +601,76 @@ public sealed class UniLabSampleScene : MonoBehaviour
         logRect.offsetMax = new Vector2(-10f, -6f);
     }
 
-    // ----- Section builders -----
+    // =========================================================
+    // Feature content builders
+    // =========================================================
 
-    private void BuildSectionLocalSave(RectTransform parent)
+    private void BuildFeatureContent_LocalSave(RectTransform parent)
     {
-        var section = AddSection(parent, "LocalSave  (PlayerPrefs + Base64 JSON)");
-        AddButtonRow(section, ("Save / Load", (Action)DemoLocalSaveSave), ("Delete", DemoLocalSaveDelete));
+        AddFeatureHeader(parent, "LocalSave", "PlayerPrefs + Base64 JSON による軽量ローカル保存。");
+        AddFeatureButtonRow(parent,
+            ("Save / Load", (Action)DemoLocalSaveSave),
+            ("Delete", DemoLocalSaveDelete));
     }
 
-    private void BuildSectionEncryptedStorage(RectTransform parent)
+    private void BuildFeatureContent_EncryptedStorage(RectTransform parent)
     {
-        var section = AddSection(parent, "EncryptedLocalStorage  (AES-256 + TTL)");
-        AddButtonRow(section, ("Save & Load", (Action)DemoEncryptedStorage), ("Delete", DemoEncryptedStorageDelete));
+        AddFeatureHeader(parent, "EncryptedStorage", "AES-256 暗号化 + TTL キャッシュ付きローカルストレージ。");
+        AddFeatureButtonRow(parent,
+            ("Save & Load", (Action)DemoEncryptedStorage),
+            ("Delete", DemoEncryptedStorageDelete));
     }
 
-    private void BuildSectionTextManager(RectTransform parent)
+    private void BuildFeatureContent_TextManager(RectTransform parent)
     {
-        var section = AddSection(parent, "TextManager  (FNV-1A localization)");
-        AddButtonRow(section, ("GetText [ja]", (Action)DemoTextManagerJa), ("GetText [en]", DemoTextManagerEn));
+        AddFeatureHeader(parent, "TextManager", "FNV-1A ハッシュベースのローカライズシステム。");
+        AddFeatureButtonRow(parent,
+            ("GetText [ja]", (Action)DemoTextManagerJa),
+            ("GetText [en]", DemoTextManagerEn));
     }
 
-    private void BuildSectionInputBlock(RectTransform parent)
+    private void BuildFeatureContent_InputBlock(RectTransform parent)
     {
-        var section = AddSection(parent, "InputBlockManager  (ref-counted block)");
-        AddButtonRow(section, ("Toggle Block", (Action)DemoToggleInputBlock));
+        AddFeatureHeader(parent, "InputBlock", "参照カウント方式の入力ブロック管理。");
+        AddFeatureButtonRow(parent,
+            ("Toggle Block", (Action)DemoToggleInputBlock));
     }
 
-    private void BuildSectionNetwork(RectTransform parent)
+    private void BuildFeatureContent_Network(RectTransform parent)
     {
-        var section = AddSection(parent, "NetworkReachabilityObservable  (polling)");
-        AddButtonRow(section, ("Check Now", (Action)DemoNetworkReachability));
+        AddFeatureHeader(parent, "Network", "R3 Observable による通信状態の監視。");
+        AddFeatureButtonRow(parent,
+            ("Check Now", (Action)DemoNetworkReachability));
     }
 
-    private void BuildSectionOfflineQueue(RectTransform parent)
+    private void BuildFeatureContent_OfflineQueue(RectTransform parent)
     {
-        var section = AddSection(parent, "OfflineQueue<T>  (persistent request queue)");
-        AddButtonRow(section,
+        AddFeatureHeader(parent, "OfflineQueue", "オフライン中のリクエストを永続化キューに積み、復帰時に送信。");
+        AddFeatureButtonRow(parent,
             ("Enqueue", (Action)DemoOfflineQueueEnqueue),
             ("Flush", DemoOfflineQueueFlush),
             ("Clear", DemoOfflineQueueClear));
     }
 
-    private void BuildSectionGrid(RectTransform parent)
+    private void BuildFeatureContent_Grid(RectTransform parent)
     {
-        var section = AddSection(parent, "VariableGridLayoutGroup  (variable-width wrap)");
+        AddFeatureHeader(parent, "Grid", "可変幅アイテムを折り返しながら並べるレイアウトグループ。");
+        AddFeatureButtonRow(parent,
+            ("+ Item", (Action)DemoGridAddItem),
+            ("Clear", DemoGridClear));
 
-        // Grid container — this is the live demo area
+        // Grid demo area — rebuilt each time this feature is shown
         var gridPanelGo = new GameObject("GridPanel", typeof(RectTransform), typeof(Image));
-        gridPanelGo.transform.SetParent(section, false);
+        gridPanelGo.transform.SetParent(parent, false);
         gridPanelGo.GetComponent<Image>().color = new Color(0.15f, 0.15f, 0.18f);
 
         _gridContainer = gridPanelGo.GetComponent<RectTransform>();
-        _gridContainer.anchorMin = new Vector2(0f, 0f);
-        _gridContainer.anchorMax = new Vector2(1f, 0f);
-        _gridContainer.pivot = new Vector2(0.5f, 0f);
-        _gridContainer.sizeDelta = new Vector2(0f, 120f);
+        _gridContainer.anchorMin = new Vector2(0f, 1f);
+        _gridContainer.anchorMax = new Vector2(1f, 1f);
+        _gridContainer.pivot = new Vector2(0.5f, 1f);
+        _gridContainer.sizeDelta = new Vector2(0f, 160f);
 
         var grid = gridPanelGo.AddComponent<VariableGridLayoutGroup>();
-        // Reflect private fields via SetFieldValue for runtime configuration
         SetField(grid, "_spacing", new Vector2(6f, 6f));
         SetField(grid, "_defaultItemSize", new Vector2(80f, 44f));
         SetField(grid, "_usePreferredWidth", true);
@@ -494,118 +680,132 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
         var sizeFitter = gridPanelGo.AddComponent<ContentSizeFitter>();
         sizeFitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-
-        AddButtonRow(section, ("+ Item", (Action)DemoGridAddItem), ("Clear", DemoGridClear));
     }
 
-    private void BuildSectionUniLabButton(RectTransform parent)
+    private void BuildFeatureContent_UniLabButton(RectTransform parent)
     {
-        var section = AddSection(parent, "UniLabButton  (Hold / Decide / State observables)");
+        AddFeatureHeader(parent, "UniLabButton", "Hold / Decide / State の Rx Observable を持つ拡張ボタン。");
 
-        // Create a UniLabButton — requires Image as targetGraphic
         var buttonGo = new GameObject("UniLabButtonDemo", typeof(Image));
-        buttonGo.transform.SetParent(section, false);
+        buttonGo.transform.SetParent(parent, false);
         var buttonImage = buttonGo.GetComponent<Image>();
         buttonImage.color = new Color(0.25f, 0.45f, 0.75f);
 
         var buttonRect = buttonGo.GetComponent<RectTransform>();
-        buttonRect.anchorMin = new Vector2(0.05f, 0f);
-        buttonRect.anchorMax = new Vector2(0.95f, 0f);
-        buttonRect.pivot = new Vector2(0.5f, 0f);
-        buttonRect.sizeDelta = new Vector2(0f, 48f);
+        buttonRect.anchorMin = new Vector2(0f, 1f);
+        buttonRect.anchorMax = new Vector2(1f, 1f);
+        buttonRect.pivot = new Vector2(0.5f, 1f);
+        buttonRect.sizeDelta = new Vector2(0f, 80f);
 
         var uniLabButton = buttonGo.AddComponent<UniLabButton>();
         uniLabButton.targetGraphic = buttonImage;
 
-        CreateLabel(buttonRect, "Press & Hold Me", 16, TextAnchor.MiddleCenter, Color.white);
+        CreateLabel(buttonRect, "Press & Hold Me", 22, TextAnchor.MiddleCenter, Color.white);
 
-        // Wire reactive observables — the core UniLabButton feature
-        _disposables.Add(uniLabButton.OnHoldAsObservable().Subscribe(_ => Log("[UniLabButton] OnHold")));
-        _disposables.Add(uniLabButton.OnDecideAsObservable().Subscribe(_ => Log("[UniLabButton] OnDecide")));
-        _disposables.Add(
+        // Wire reactive observables — use _featureDisposables so they are released on screen transition
+        _featureDisposables.Add(uniLabButton.OnHoldAsObservable().Subscribe(_ => Log("[UniLabButton] OnHold")));
+        _featureDisposables.Add(uniLabButton.OnDecideAsObservable().Subscribe(_ => Log("[UniLabButton] OnDecide")));
+        _featureDisposables.Add(
             uniLabButton.StateAsObservable()
                 .Where(state => state != ButtonState.None)
                 .Subscribe(state => Log($"[UniLabButton] State → {state}")));
     }
 
-    private void BuildSectionAnimationPlayer(RectTransform parent)
+    private void BuildFeatureContent_AnimationPlayer(RectTransform parent)
     {
-        var section = AddSection(parent, "AnimationPlayer  (async + observables)");
-        AddButtonRow(section, ("Setup Demo", (Action)DemoAnimationPlayerSetup));
+        AddFeatureHeader(parent, "AnimationPlayer", "Animator の非同期再生と OnPlay / OnComplete Observable のラッパー。");
+        AddFeatureButtonRow(parent,
+            ("Setup Demo", (Action)DemoAnimationPlayerSetup));
     }
 
-    private void BuildSectionToast(RectTransform parent)
+    private void BuildFeatureContent_Toast(RectTransform parent)
     {
-        var section = AddSection(parent, "ToastManager  [Prefab Required]");
-        AddButtonRow(section,
+        AddFeatureHeader(parent, "Toast", "[Prefab Required] _hasToastManager を有効化してから使用。");
+        AddFeatureButtonRow(parent,
             ("Info", (Action)DemoToastInfo),
             ("Success", DemoToastSuccess),
             ("Error", DemoToastError));
     }
 
-    private void BuildSectionLoading(RectTransform parent)
+    private void BuildFeatureContent_Loading(RectTransform parent)
     {
-        var section = AddSection(parent, "LoadingOverlayManager  [Prefab Required]");
-        AddButtonRow(section, ("Show 1.5 s", (Action)DemoLoadingOverlay));
+        AddFeatureHeader(parent, "Loading", "[Prefab Required] _hasLoadingManager を有効化してから使用。");
+        AddFeatureButtonRow(parent,
+            ("Show 1.5 s", (Action)DemoLoadingOverlay));
     }
 
-    private void BuildSectionBackKey(RectTransform parent)
+    private void BuildFeatureContent_BackKey(RectTransform parent)
     {
-        var section = AddSection(parent, "BackKeyInputManager  (Android back key)");
-        AddButtonRow(section, ("Toggle Block", (Action)DemoBackKeyToggleBlock));
+        AddFeatureHeader(parent, "BackKey", "Android バックキーの Observable ラッパー。IsBlocked でブロック可能。");
+        AddFeatureButtonRow(parent,
+            ("Toggle Block", (Action)DemoBackKeyToggleBlock));
     }
 
-    // ----- UI helpers -----
+    // =========================================================
+    // Feature screen layout helpers
+    // =========================================================
 
-    /// <summary>Creates a titled section container inside a vertical scroll content.</summary>
-    private RectTransform AddSection(RectTransform parent, string title)
+    private void AddFeatureHeader(RectTransform parent, string title, string description)
     {
-        const float sectionPadding = 10f;
-
-        // Section wrapper
-        var sectionGo = new GameObject($"Section_{title}", typeof(RectTransform), typeof(Image));
-        sectionGo.transform.SetParent(parent, false);
-        sectionGo.GetComponent<Image>().color = new Color(0.12f, 0.12f, 0.15f);
-        var sectionRect = sectionGo.GetComponent<RectTransform>();
-        sectionRect.anchorMin = new Vector2(0f, 1f);
-        sectionRect.anchorMax = new Vector2(1f, 1f);
-        sectionRect.pivot = new Vector2(0.5f, 1f);
-
-        var layout = sectionGo.AddComponent<VerticalLayoutGroup>();
-        layout.padding = new RectOffset(8, 8, 6, 8);
-        layout.spacing = sectionPadding;
-        layout.childControlWidth = true;
-        layout.childControlHeight = false;
-        layout.childForceExpandWidth = true;
-        layout.childForceExpandHeight = false;
-
-        var fitter = sectionGo.AddComponent<ContentSizeFitter>();
-        fitter.verticalFit = ContentSizeFitter.FitMode.PreferredSize;
-
-        // Title label
-        var titleGo = new GameObject("Title", typeof(Text));
-        titleGo.transform.SetParent(sectionGo.transform, false);
+        // Feature title
+        var titleGo = new GameObject("FeatureTitle", typeof(Text));
+        titleGo.transform.SetParent(parent, false);
         var titleText = titleGo.GetComponent<Text>();
         titleText.font = _font;
-        titleText.fontSize = 16;
+        titleText.fontSize = 32;
         titleText.fontStyle = FontStyle.Bold;
-        titleText.color = new Color(0.8f, 0.85f, 1f);
+        titleText.color = Color.white;
         titleText.text = title;
+        titleText.alignment = TextAnchor.MiddleLeft;
+        titleText.horizontalOverflow = HorizontalWrapMode.Wrap;
+        titleText.verticalOverflow = VerticalWrapMode.Overflow;
         var titleRect = titleGo.GetComponent<RectTransform>();
-        titleRect.sizeDelta = new Vector2(0f, 24f);
+        titleRect.anchorMin = new Vector2(0f, 1f);
+        titleRect.anchorMax = new Vector2(1f, 1f);
+        titleRect.pivot = new Vector2(0.5f, 1f);
+        titleRect.sizeDelta = new Vector2(0f, 52f);
 
-        return sectionRect;
+        // Description
+        var descGo = new GameObject("Description", typeof(Text));
+        descGo.transform.SetParent(parent, false);
+        var descText = descGo.GetComponent<Text>();
+        descText.font = _font;
+        descText.fontSize = 20;
+        descText.color = new Color(0.7f, 0.7f, 0.7f);
+        descText.text = description;
+        descText.alignment = TextAnchor.UpperLeft;
+        descText.horizontalOverflow = HorizontalWrapMode.Wrap;
+        descText.verticalOverflow = VerticalWrapMode.Overflow;
+        var descRect = descGo.GetComponent<RectTransform>();
+        descRect.anchorMin = new Vector2(0f, 1f);
+        descRect.anchorMax = new Vector2(1f, 1f);
+        descRect.pivot = new Vector2(0.5f, 1f);
+        descRect.sizeDelta = new Vector2(0f, 48f);
+
+        // Divider
+        var dividerGo = new GameObject("Divider", typeof(Image));
+        dividerGo.transform.SetParent(parent, false);
+        dividerGo.GetComponent<Image>().color = new Color(0.3f, 0.3f, 0.35f);
+        var dividerRect = dividerGo.GetComponent<RectTransform>();
+        dividerRect.anchorMin = new Vector2(0f, 1f);
+        dividerRect.anchorMax = new Vector2(1f, 1f);
+        dividerRect.pivot = new Vector2(0.5f, 1f);
+        dividerRect.sizeDelta = new Vector2(0f, 2f);
     }
 
-    private void AddButtonRow(RectTransform section, params (string label, Action onClick)[] buttons)
+    private void AddFeatureButtonRow(RectTransform parent, params (string label, Action onClick)[] buttons)
     {
         var rowGo = new GameObject("ButtonRow", typeof(RectTransform));
-        rowGo.transform.SetParent(section, false);
+        rowGo.transform.SetParent(parent, false);
         var rowRect = rowGo.GetComponent<RectTransform>();
-        rowRect.sizeDelta = new Vector2(0f, 48f);
+        rowRect.anchorMin = new Vector2(0f, 1f);
+        rowRect.anchorMax = new Vector2(1f, 1f);
+        rowRect.pivot = new Vector2(0.5f, 1f);
+        rowRect.sizeDelta = new Vector2(0f, 80f);
 
         var rowLayout = rowGo.AddComponent<HorizontalLayoutGroup>();
         rowLayout.spacing = 8f;
+        rowLayout.padding = new RectOffset(0, 0, 0, 0);
         rowLayout.childControlWidth = true;
         rowLayout.childControlHeight = true;
         rowLayout.childForceExpandWidth = true;
@@ -613,11 +813,11 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
         foreach (var (label, onClick) in buttons)
         {
-            CreateButton(rowGo.transform, label, onClick);
+            CreateFeatureButton(rowGo.transform, label, onClick);
         }
     }
 
-    private void CreateButton(Transform parent, string label, Action onClick)
+    private void CreateFeatureButton(Transform parent, string label, Action onClick)
     {
         var buttonGo = new GameObject($"Btn_{label}", typeof(Image));
         buttonGo.transform.SetParent(parent, false);
@@ -633,8 +833,12 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
         button.onClick.AddListener(() => onClick());
 
-        CreateLabel(buttonGo.GetComponent<RectTransform>(), label, 15, TextAnchor.MiddleCenter, Color.white);
+        CreateLabel(buttonGo.GetComponent<RectTransform>(), label, 22, TextAnchor.MiddleCenter, Color.white);
     }
+
+    // =========================================================
+    // UI helpers
+    // =========================================================
 
     private Text CreateLabel(RectTransform parent, string text, int fontSize, TextAnchor alignment, Color color)
     {

--- a/Assets/UniLab/Sample/UniLabSampleScene.cs
+++ b/Assets/UniLab/Sample/UniLabSampleScene.cs
@@ -59,6 +59,13 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private Text _logText;
     private readonly List<string> _logLines = new();
     private const int MaxLogLines = 14;
+
+    // Status color constants for feature status panels.
+    private static readonly Color StatusColorNeutral = new Color(0.12f, 0.12f, 0.18f);
+    private static readonly Color StatusColorSuccess = new Color(0.10f, 0.28f, 0.15f);
+    private static readonly Color StatusColorWarning = new Color(0.32f, 0.20f, 0.08f);
+    private static readonly Color StatusColorError   = new Color(0.28f, 0.10f, 0.10f);
+
     private Font _font;
 
     private GameObject _menuPanel;
@@ -72,6 +79,11 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
     // Per-feature subscriptions (e.g. UniLabButton) — cleared on each ShowFeature call
     private readonly CompositeDisposable _featureDisposables = new();
+
+    // Status display for the currently shown feature screen.
+    // Set by BuildFeatureContent_*, updated by Demo* methods.
+    private Image _featureStatusImage;
+    private Text _featureStatusText;
 
     // ----- Feature state -----
 
@@ -182,6 +194,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         LocalSave.Save(new SampleSaveData { Counter = _localSaveCounter, Label = "hello" });
         var loaded = LocalSave.Load<SampleSaveData>();
         Log($"[LocalSave] Saved {_localSaveCounter}  →  loaded counter={loaded.Counter}");
+        RefreshLocalSaveStatus();
     }
 
     private void DemoLocalSaveDelete()
@@ -189,6 +202,20 @@ public sealed class UniLabSampleScene : MonoBehaviour
         LocalSave.Delete<SampleSaveData>();
         var loaded = LocalSave.Load<SampleSaveData>();
         Log($"[LocalSave] Deleted. Default load: counter={loaded.Counter}");
+        RefreshLocalSaveStatus();
+    }
+
+    private void RefreshLocalSaveStatus()
+    {
+        var loaded = LocalSave.Load<SampleSaveData>();
+        if (loaded.Counter == 0 && loaded.Label == null)
+        {
+            UpdateStatus("No data saved.", StatusColorNeutral);
+        }
+        else
+        {
+            UpdateStatus($"Counter : {loaded.Counter}\nLabel   : {loaded.Label}", StatusColorSuccess);
+        }
     }
 
     // --- Encrypted Storage ---
@@ -199,12 +226,14 @@ public sealed class UniLabSampleScene : MonoBehaviour
         _encryptedStorage.Save("demo_key", data, TimeSpan.FromMinutes(10));
         var loaded = _encryptedStorage.Load<SampleSaveData>("demo_key");
         Log($"[Storage] AES-saved & loaded: counter={loaded.Counter} label={loaded.Label}");
+        UpdateStatus("demo_key: ✓ Saved\nCounter : 99 / Label : secret", StatusColorSuccess);
     }
 
     private void DemoEncryptedStorageDelete()
     {
         _encryptedStorage.Delete("demo_key");
         Log("[Storage] Deleted demo_key. Exists=" + _encryptedStorage.Exists("demo_key"));
+        UpdateStatus("demo_key: — Not found", StatusColorError);
     }
 
     // --- TextManager ---
@@ -215,6 +244,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         // Requires LocalizationData asset in Resources; returns [Missing:…] without it.
         var text = TextManager.GetText("app_title");
         Log($"[Text] ja: app_title = {text}");
+        UpdateStatus($"Language : JA\napp_title = {text}", StatusColorSuccess);
     }
 
     private void DemoTextManagerEn()
@@ -223,6 +253,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         var text = TextManager.GetText("app_title");
         Log($"[Text] en: app_title = {text}");
         TextManager.SetLanguage("ja"); // restore
+        UpdateStatus($"Language : EN\napp_title = {text}", StatusColorSuccess);
     }
 
     // --- InputBlockManager ---
@@ -234,11 +265,13 @@ public sealed class UniLabSampleScene : MonoBehaviour
             _inputBlockHandle.Dispose();
             _inputBlockHandle = null;
             Log($"[InputBlock] Released. BlockedInput={InputBlockManager.BlockedInput}");
+            UpdateStatus("Input: Open", StatusColorSuccess);
         }
         else
         {
             _inputBlockHandle = InputBlockManager.CreateInputBlock();
             Log($"[InputBlock] Created. BlockedInput={InputBlockManager.BlockedInput}");
+            UpdateStatus("Input: BLOCKED", StatusColorError);
         }
     }
 
@@ -246,7 +279,20 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
     private void DemoNetworkReachability()
     {
-        Log($"[Network] Current: {Application.internetReachability}");
+        var reachability = Application.internetReachability;
+        Log($"[Network] Current: {reachability}");
+        switch (reachability)
+        {
+            case NetworkReachability.ReachableViaLocalAreaNetwork:
+                UpdateStatus("Reachability: WiFi ✓", StatusColorSuccess);
+                break;
+            case NetworkReachability.ReachableViaCarrierDataNetwork:
+                UpdateStatus("Reachability: Mobile ✓", StatusColorWarning);
+                break;
+            default:
+                UpdateStatus("Reachability: Not Reachable ✗", StatusColorError);
+                break;
+        }
     }
 
     // --- OfflineQueue ---
@@ -256,6 +302,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         var key = $"req_{DateTimeOffset.UtcNow.ToUnixTimeMilliseconds()}";
         _offlineQueue.Enqueue(key, new SamplePendingRequest { Endpoint = "/api/demo", Body = "payload" });
         Log($"[OfflineQueue] Enqueued. Count={_offlineQueue.Count}");
+        RefreshOfflineQueueStatus();
     }
 
     private void DemoOfflineQueueFlush()
@@ -265,6 +312,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
     private async UniTaskVoid FlushOfflineQueueAsync()
     {
+        UpdateStatus("Flushing...", StatusColorWarning);
         var flushedCount = 0;
         await _offlineQueue.FlushAsync(async (request, ct) =>
         {
@@ -273,12 +321,22 @@ public sealed class UniLabSampleScene : MonoBehaviour
             Log($"[OfflineQueue] Sent: {request.Endpoint}");
         }, destroyCancellationToken);
         Log($"[OfflineQueue] Flush done. Sent={flushedCount} Remaining={_offlineQueue.Count}");
+        RefreshOfflineQueueStatus();
     }
 
     private void DemoOfflineQueueClear()
     {
         _offlineQueue.Clear();
         Log($"[OfflineQueue] Cleared. Count={_offlineQueue.Count}");
+        RefreshOfflineQueueStatus();
+    }
+
+    private void RefreshOfflineQueueStatus()
+    {
+        var count = _offlineQueue.Count;
+        UpdateStatus(
+            count == 0 ? "Queue: empty" : $"Queue: {count} item(s) pending",
+            count == 0 ? StatusColorNeutral : StatusColorWarning);
     }
 
     // --- VariableGridLayoutGroup ---
@@ -308,6 +366,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         label.fontSize = 13;
         label.color = Color.white;
         label.alignment = TextAnchor.MiddleCenter;
+        label.raycastTarget = false;
         label.text = _gridChildCount.ToString();
         var labelRect = label.GetComponent<RectTransform>();
         labelRect.anchorMin = Vector2.zero;
@@ -316,6 +375,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
 
         LayoutRebuilder.MarkLayoutForRebuild(_gridContainer);
         Log($"[Grid] Added item {_gridChildCount} (w={width})");
+        UpdateStatus($"Items: {_gridChildCount}", StatusColorSuccess);
     }
 
     private void DemoGridClear()
@@ -326,6 +386,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         }
         _gridChildCount = 0;
         Log("[Grid] Cleared");
+        UpdateStatus("Items: 0", StatusColorNeutral);
     }
 
     // --- AnimationPlayer ---
@@ -338,11 +399,12 @@ public sealed class UniLabSampleScene : MonoBehaviour
         go.AddComponent<Animator>(); // AnimationPlayer requires Animator on the same GameObject
         var player = go.AddComponent<AnimationPlayer>();
 
-        _disposables.Add(player.OnPlay.Subscribe(_ => Log("[Animation] OnPlay fired")));
-        _disposables.Add(player.OnComplete.Subscribe(_ => Log("[Animation] OnComplete fired")));
+        _disposables.Add(player.OnPlay.Subscribe(_ => { Log("[Animation] OnPlay fired"); UpdateStatus("IsPlaying: true", StatusColorSuccess); }));
+        _disposables.Add(player.OnComplete.Subscribe(_ => { Log("[Animation] OnComplete fired"); UpdateStatus("IsPlaying: false", StatusColorNeutral); }));
 
         Log("[Animation] AnimationPlayer set up. IsPlaying=" + player.IsPlaying);
         Log("[Animation] Call player.PlayAsync(\"StateName\") with a real AnimatorController to play.");
+        UpdateStatus("IsPlaying: false\nOnPlay / OnComplete subscribed", StatusColorSuccess);
 
         // Demonstrate the async call signature (returns immediately — animation name is empty)
         player.PlayAsync().Forget();
@@ -359,6 +421,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         if (!_hasToastManager)
         {
             Log("[Toast] Skipped — enable _hasToastManager after adding ToastManager prefab to scene");
+            UpdateStatus("⚠ _hasToastManager is disabled.\nEnable in Inspector.", StatusColorWarning);
             return;
         }
 
@@ -366,6 +429,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         {
             ToastManager.Instance.Show(message, type);
             Log($"[Toast] Shown ({type}): {message}");
+            UpdateStatus($"Last: {type}\n\"{message}\"", StatusColorSuccess);
         }
         catch (Exception exception)
         {
@@ -380,6 +444,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         if (!_hasLoadingManager)
         {
             Log("[Loading] Skipped — enable _hasLoadingManager after adding LoadingOverlayManager prefab to scene");
+            UpdateStatus("⚠ _hasLoadingManager is disabled.\nEnable in Inspector.", StatusColorWarning);
             return;
         }
 
@@ -391,12 +456,15 @@ public sealed class UniLabSampleScene : MonoBehaviour
         try
         {
             using var handle = LoadingOverlayManager.Instance.Show();
+            UpdateStatus("Overlay: Visible", StatusColorWarning);
             Log("[Loading] Overlay shown (1.5 s)...");
             await UniTask.Delay(1500, cancellationToken: destroyCancellationToken);
+            UpdateStatus("Overlay: Hidden", StatusColorNeutral);
         }
         catch (Exception exception)
         {
             Log($"[Loading] Error: {exception.Message}");
+            UpdateStatus($"Error: {exception.Message}", StatusColorError);
         }
         Log("[Loading] Overlay hidden");
     }
@@ -408,6 +476,9 @@ public sealed class UniLabSampleScene : MonoBehaviour
         var manager = BackKeyInputManager.Instance;
         manager.SetBlock(!manager.IsBlocked);
         Log($"[BackKey] IsBlocked={manager.IsBlocked} (Android only; Observable always active)");
+        UpdateStatus(
+            manager.IsBlocked ? "Back Key: BLOCKED" : "Back Key: Active",
+            manager.IsBlocked ? StatusColorError : StatusColorSuccess);
     }
 
     // =========================================================
@@ -592,6 +663,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         _logText.font = _font;
         _logText.fontSize = 20;
         _logText.color = new Color(0.6f, 1f, 0.6f);
+        _logText.raycastTarget = false;
         _logText.horizontalOverflow = HorizontalWrapMode.Wrap;
         _logText.verticalOverflow = VerticalWrapMode.Overflow;
         var logRect = logGo.GetComponent<RectTransform>();
@@ -608,6 +680,8 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_LocalSave(RectTransform parent)
     {
         AddFeatureHeader(parent, "LocalSave", "PlayerPrefs + Base64 JSON による軽量ローカル保存。");
+        AddStatusDisplay(parent, "No data saved.", StatusColorNeutral);
+        RefreshLocalSaveStatus();
         AddFeatureButtonRow(parent,
             ("Save / Load", (Action)DemoLocalSaveSave),
             ("Delete", DemoLocalSaveDelete));
@@ -616,6 +690,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_EncryptedStorage(RectTransform parent)
     {
         AddFeatureHeader(parent, "EncryptedStorage", "AES-256 暗号化 + TTL キャッシュ付きローカルストレージ。");
+        AddStatusDisplay(parent, "demo_key: — Not found", StatusColorError);
         AddFeatureButtonRow(parent,
             ("Save & Load", (Action)DemoEncryptedStorage),
             ("Delete", DemoEncryptedStorageDelete));
@@ -624,6 +699,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_TextManager(RectTransform parent)
     {
         AddFeatureHeader(parent, "TextManager", "FNV-1A ハッシュベースのローカライズシステム。");
+        AddStatusDisplay(parent, "Language: JA\napp_title = [tap a button]", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("GetText [ja]", (Action)DemoTextManagerJa),
             ("GetText [en]", DemoTextManagerEn));
@@ -632,6 +708,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_InputBlock(RectTransform parent)
     {
         AddFeatureHeader(parent, "InputBlock", "参照カウント方式の入力ブロック管理。");
+        AddStatusDisplay(parent, "Input: Open", StatusColorSuccess);
         AddFeatureButtonRow(parent,
             ("Toggle Block", (Action)DemoToggleInputBlock));
     }
@@ -639,6 +716,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_Network(RectTransform parent)
     {
         AddFeatureHeader(parent, "Network", "R3 Observable による通信状態の監視。");
+        AddStatusDisplay(parent, $"Reachability: {Application.internetReachability}", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("Check Now", (Action)DemoNetworkReachability));
     }
@@ -646,6 +724,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_OfflineQueue(RectTransform parent)
     {
         AddFeatureHeader(parent, "OfflineQueue", "オフライン中のリクエストを永続化キューに積み、復帰時に送信。");
+        AddStatusDisplay(parent, "Queue: empty", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("Enqueue", (Action)DemoOfflineQueueEnqueue),
             ("Flush", DemoOfflineQueueFlush),
@@ -655,6 +734,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_Grid(RectTransform parent)
     {
         AddFeatureHeader(parent, "Grid", "可変幅アイテムを折り返しながら並べるレイアウトグループ。");
+        AddStatusDisplay(parent, "Items: 0", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("+ Item", (Action)DemoGridAddItem),
             ("Clear", DemoGridClear));
@@ -662,7 +742,9 @@ public sealed class UniLabSampleScene : MonoBehaviour
         // Grid demo area — rebuilt each time this feature is shown
         var gridPanelGo = new GameObject("GridPanel", typeof(RectTransform), typeof(Image));
         gridPanelGo.transform.SetParent(parent, false);
-        gridPanelGo.GetComponent<Image>().color = new Color(0.15f, 0.15f, 0.18f);
+        var gridPanelImage = gridPanelGo.GetComponent<Image>();
+        gridPanelImage.color = new Color(0.15f, 0.15f, 0.18f);
+        gridPanelImage.raycastTarget = false;
 
         _gridContainer = gridPanelGo.GetComponent<RectTransform>();
         _gridContainer.anchorMin = new Vector2(0f, 1f);
@@ -685,6 +767,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_UniLabButton(RectTransform parent)
     {
         AddFeatureHeader(parent, "UniLabButton", "Hold / Decide / State の Rx Observable を持つ拡張ボタン。");
+        AddStatusDisplay(parent, "State: None", StatusColorNeutral);
 
         var buttonGo = new GameObject("UniLabButtonDemo", typeof(Image));
         buttonGo.transform.SetParent(parent, false);
@@ -707,13 +790,38 @@ public sealed class UniLabSampleScene : MonoBehaviour
         _featureDisposables.Add(uniLabButton.OnDecideAsObservable().Subscribe(_ => Log("[UniLabButton] OnDecide")));
         _featureDisposables.Add(
             uniLabButton.StateAsObservable()
-                .Where(state => state != ButtonState.None)
-                .Subscribe(state => Log($"[UniLabButton] State → {state}")));
+                .Subscribe(state =>
+                {
+                    Log($"[UniLabButton] State → {state}");
+                    string statusText;
+                    Color statusColor;
+                    switch (state)
+                    {
+                        case ButtonState.Down:
+                            statusText = "State: Pressing";
+                            statusColor = StatusColorSuccess;
+                            break;
+                        case ButtonState.Hold:
+                            statusText = "State: Holding";
+                            statusColor = StatusColorWarning;
+                            break;
+                        case ButtonState.Up:
+                            statusText = "State: Up";
+                            statusColor = StatusColorNeutral;
+                            break;
+                        default:
+                            statusText = "State: None";
+                            statusColor = StatusColorNeutral;
+                            break;
+                    }
+                    UpdateStatus(statusText, statusColor);
+                }));
     }
 
     private void BuildFeatureContent_AnimationPlayer(RectTransform parent)
     {
         AddFeatureHeader(parent, "AnimationPlayer", "Animator の非同期再生と OnPlay / OnComplete Observable のラッパー。");
+        AddStatusDisplay(parent, "IsPlaying: —\n(tap Setup to initialize)", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("Setup Demo", (Action)DemoAnimationPlayerSetup));
     }
@@ -721,6 +829,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_Toast(RectTransform parent)
     {
         AddFeatureHeader(parent, "Toast", "[Prefab Required] _hasToastManager を有効化してから使用。");
+        AddStatusDisplay(parent, "Last toast: (none)", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("Info", (Action)DemoToastInfo),
             ("Success", DemoToastSuccess),
@@ -730,6 +839,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_Loading(RectTransform parent)
     {
         AddFeatureHeader(parent, "Loading", "[Prefab Required] _hasLoadingManager を有効化してから使用。");
+        AddStatusDisplay(parent, "Overlay: Hidden", StatusColorNeutral);
         AddFeatureButtonRow(parent,
             ("Show 1.5 s", (Action)DemoLoadingOverlay));
     }
@@ -737,6 +847,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     private void BuildFeatureContent_BackKey(RectTransform parent)
     {
         AddFeatureHeader(parent, "BackKey", "Android バックキーの Observable ラッパー。IsBlocked でブロック可能。");
+        AddStatusDisplay(parent, "Back Key: Active", StatusColorSuccess);
         AddFeatureButtonRow(parent,
             ("Toggle Block", (Action)DemoBackKeyToggleBlock));
     }
@@ -757,6 +868,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         titleText.color = Color.white;
         titleText.text = title;
         titleText.alignment = TextAnchor.MiddleLeft;
+        titleText.raycastTarget = false;
         titleText.horizontalOverflow = HorizontalWrapMode.Wrap;
         titleText.verticalOverflow = VerticalWrapMode.Overflow;
         var titleRect = titleGo.GetComponent<RectTransform>();
@@ -774,6 +886,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         descText.color = new Color(0.7f, 0.7f, 0.7f);
         descText.text = description;
         descText.alignment = TextAnchor.UpperLeft;
+        descText.raycastTarget = false;
         descText.horizontalOverflow = HorizontalWrapMode.Wrap;
         descText.verticalOverflow = VerticalWrapMode.Overflow;
         var descRect = descGo.GetComponent<RectTransform>();
@@ -785,7 +898,9 @@ public sealed class UniLabSampleScene : MonoBehaviour
         // Divider
         var dividerGo = new GameObject("Divider", typeof(Image));
         dividerGo.transform.SetParent(parent, false);
-        dividerGo.GetComponent<Image>().color = new Color(0.3f, 0.3f, 0.35f);
+        var dividerImage = dividerGo.GetComponent<Image>();
+        dividerImage.color = new Color(0.3f, 0.3f, 0.35f);
+        dividerImage.raycastTarget = false;
         var dividerRect = dividerGo.GetComponent<RectTransform>();
         dividerRect.anchorMin = new Vector2(0f, 1f);
         dividerRect.anchorMax = new Vector2(1f, 1f);
@@ -860,6 +975,40 @@ public sealed class UniLabSampleScene : MonoBehaviour
         rect.offsetMin = new Vector2(4f, 0f);
         rect.offsetMax = new Vector2(-4f, 0f);
         return label;
+    }
+
+    /// <summary>
+    /// Adds a 140px-tall status display panel to the feature content area.
+    /// Sets _featureStatusImage and _featureStatusText for later updates.
+    /// </summary>
+    private void AddStatusDisplay(RectTransform parent, string initialText, Color initialColor)
+    {
+        var panelGo = new GameObject("StatusPanel", typeof(Image));
+        panelGo.transform.SetParent(parent, false);
+        var panelImage = panelGo.GetComponent<Image>();
+        panelImage.color = initialColor;
+        panelImage.raycastTarget = false;
+
+        var panelRect = panelGo.GetComponent<RectTransform>();
+        panelRect.anchorMin = new Vector2(0f, 1f);
+        panelRect.anchorMax = new Vector2(1f, 1f);
+        panelRect.pivot = new Vector2(0.5f, 1f);
+        panelRect.sizeDelta = new Vector2(0f, 140f);
+
+        var statusLabel = CreateLabel(panelRect, initialText, 20, TextAnchor.UpperLeft, Color.white);
+        var labelRect = statusLabel.GetComponent<RectTransform>();
+        labelRect.offsetMin = new Vector2(12f, 8f);
+        labelRect.offsetMax = new Vector2(-12f, -8f);
+
+        _featureStatusImage = panelImage;
+        _featureStatusText = statusLabel;
+    }
+
+    /// <summary>Updates the status panel color and text.</summary>
+    private void UpdateStatus(string text, Color color)
+    {
+        if (_featureStatusImage != null) { _featureStatusImage.color = color; }
+        if (_featureStatusText  != null) { _featureStatusText.text   = text;  }
     }
 
     // Background panels are purely visual — never used as raycast targets.

--- a/Assets/UniLab/Sample/UniLabSampleScene.cs
+++ b/Assets/UniLab/Sample/UniLabSampleScene.cs
@@ -840,6 +840,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
     // UI helpers
     // =========================================================
 
+    // Labels are purely visual — never used as raycast targets.
     private Text CreateLabel(RectTransform parent, string text, int fontSize, TextAnchor alignment, Color color)
     {
         var go = new GameObject("Label", typeof(Text));
@@ -850,6 +851,7 @@ public sealed class UniLabSampleScene : MonoBehaviour
         label.color = color;
         label.text = text;
         label.alignment = alignment;
+        label.raycastTarget = false;
         label.horizontalOverflow = HorizontalWrapMode.Wrap;
         label.verticalOverflow = VerticalWrapMode.Overflow;
         var rect = go.GetComponent<RectTransform>();
@@ -860,20 +862,28 @@ public sealed class UniLabSampleScene : MonoBehaviour
         return label;
     }
 
+    // Background panels are purely visual — never used as raycast targets.
+    // Button GameObjects are created separately and keep the default raycastTarget = true.
     private RectTransform CreatePanel(Transform parent, string name, Color color)
     {
         var go = new GameObject(name, typeof(Image));
         go.transform.SetParent(parent, false);
-        go.GetComponent<Image>().color = color;
+        var image = go.GetComponent<Image>();
+        image.color = color;
+        image.raycastTarget = false;
         return go.GetComponent<RectTransform>();
     }
 
     private ScrollRect BuildScrollRect(Transform parent, Vector2 anchorMin, Vector2 anchorMax)
     {
-        // Scroll root
+        // Scroll root: transparent Image is visual only; raycastTarget = false.
+        // The Viewport Image below keeps raycastTarget = true so that ScrollRect
+        // receives drag/scroll events when the content area is empty.
         var scrollGo = new GameObject("ScrollView", typeof(RectTransform), typeof(Image));
         scrollGo.transform.SetParent(parent, false);
-        scrollGo.GetComponent<Image>().color = new Color(0f, 0f, 0f, 0f);
+        var scrollRootImage = scrollGo.GetComponent<Image>();
+        scrollRootImage.color = new Color(0f, 0f, 0f, 0f);
+        scrollRootImage.raycastTarget = false;
         var scrollRect = scrollGo.AddComponent<ScrollRect>();
         SetAnchoredLayout(scrollGo.GetComponent<RectTransform>(), anchorMin, anchorMax);
 

--- a/Assets/UniLab/UIComponent/InputBlockManager.cs.meta
+++ b/Assets/UniLab/UIComponent/InputBlockManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd8e656eda4c84d4db1419caeff92f46

--- a/Assets/UniLab/UIComponent/Loading.meta
+++ b/Assets/UniLab/UIComponent/Loading.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5d8e2d140b8c54af887ff5244547fe84
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Loading/Interface.meta
+++ b/Assets/UniLab/UIComponent/Loading/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f64341ca3d2ce4a9692acf97b9cfb32b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Loading/Interface/ILoadingOverlayManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Loading/Interface/ILoadingOverlayManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 84d4a162899e2407abed15873833872c

--- a/Assets/UniLab/UIComponent/Loading/LoadingOverlayManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Loading/LoadingOverlayManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f824539f086ba4875a276bdab9ad3c7c

--- a/Assets/UniLab/UIComponent/Popup.meta
+++ b/Assets/UniLab/UIComponent/Popup.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 185af0861a9e84823b01abddd3fc7eac
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Popup/Base.meta
+++ b/Assets/UniLab/UIComponent/Popup/Base.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1ccf9f9c4cc3d42a78b3bbb4932acb7f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Popup/Base/PopupBase.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Base/PopupBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 134bde3946231498fa529d489dff3f3f

--- a/Assets/UniLab/UIComponent/Popup/Base/PopupBaseWrapper.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Base/PopupBaseWrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c9fe4eaaa9e324de68ecf05d29c96d59

--- a/Assets/UniLab/UIComponent/Popup/Base/PopupManagerBase.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Base/PopupManagerBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1fd274ea919643b88b000391f7ba6c0

--- a/Assets/UniLab/UIComponent/Popup/ConfirmPopup.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/ConfirmPopup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 25a6fd7d1f35d4421abb32d33e478742

--- a/Assets/UniLab/UIComponent/Popup/Interface.meta
+++ b/Assets/UniLab/UIComponent/Popup/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 02cee2adec6644007be497d9cdd619c9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba4c3a9fcb32b4c5e9e505c860798707

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupParameter.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupParameter.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ec0dce7d62034e18b2df4daa04d2db6

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupView.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 390545b14a1ca4f4492ec770e6951e86

--- a/Assets/UniLab/UIComponent/Popup/UniLabPopupManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/UniLabPopupManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3decc6cda541d43b1ad6910a4086784b

--- a/Assets/UniLab/UIComponent/SwipeDetector.cs.meta
+++ b/Assets/UniLab/UIComponent/SwipeDetector.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d44870fa797a34b97ab6ffac2d160879

--- a/Assets/UniLab/UIComponent/Toast.meta
+++ b/Assets/UniLab/UIComponent/Toast.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b6cebc0c3988e42a28fc061f0eab9a02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Toast/Interface.meta
+++ b/Assets/UniLab/UIComponent/Toast/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0ed4e1352cd8d4c0b99f95044caea5f5
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Toast/Interface/IToastManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Toast/Interface/IToastManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e8fb382716e434b259004532088bed79

--- a/Assets/UniLab/UIComponent/Toast/ToastManager.cs.meta
+++ b/Assets/UniLab/UIComponent/Toast/ToastManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be1a4e028760a4d46b55a741241660f2

--- a/Assets/UniLab/UIComponent/Toast/ToastView.cs.meta
+++ b/Assets/UniLab/UIComponent/Toast/ToastView.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 41cdd4594ede342019da25dd73548ba7

--- a/Assets/UniLab/UIComponent/Transition.meta
+++ b/Assets/UniLab/UIComponent/Transition.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c8c7e3fb9f380427ab587e3d84051217
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Transition/Interface.meta
+++ b/Assets/UniLab/UIComponent/Transition/Interface.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a253a699d149b4ca5b70113534582fe3
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Transition/Interface/ISceneTransition.cs.meta
+++ b/Assets/UniLab/UIComponent/Transition/Interface/ISceneTransition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 625f3fb85838942939af73a40b0cda61

--- a/Assets/UniLab/UIComponent/Transition/SceneFadeTransition.cs.meta
+++ b/Assets/UniLab/UIComponent/Transition/SceneFadeTransition.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f47351ffcec794140ba320c1012ac323

--- a/Assets/UniLab/UIComponent/UIInputBlockingManagerBase.cs.meta
+++ b/Assets/UniLab/UIComponent/UIInputBlockingManagerBase.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 61a62af558a0e43b3b40fc65e5ea3926

--- a/Assets/UniLab/UIComponent/UISafeArea.cs.meta
+++ b/Assets/UniLab/UIComponent/UISafeArea.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: bd00aa940a1f24b938c1119d8e665b49

--- a/docs/devlog/2026-03-30-sample-scene-design.md
+++ b/docs/devlog/2026-03-30-sample-scene-design.md
@@ -1,0 +1,72 @@
+# Sample Scene Design — 2026-03-30
+
+## ナビゲーション構成
+
+メニュー画面 → 機能詳細画面の2パネル切り替え。シーンロードなし。
+
+```
+UniLabSampleCanvas (Canvas)
+  BG                   (Image, raycastTarget=false)
+  MenuPanel            (RectTransform) ← active on menu
+    ScrollView         (Image raycastTarget=false, ScrollRect)
+      Viewport         (Image raycastTarget=true ← ScrollRect のドラッグ受け口)
+        Content        (VerticalLayoutGroup + ContentSizeFitter)
+          MenuBtn_*    (Image raycastTarget=true + Button)  ← ボタンのみ true
+  FeaturePanel         (RectTransform) ← active on feature
+    ScrollView         ... (同上構成)
+  LogPanel             (Image, raycastTarget=false)
+  Header               (Image, raycastTarget=false) ← 最後のsibling = raycast最優先
+    BackButton         (Image raycastTarget=true + Button)
+    Label              (Text, raycastTarget=false)
+```
+
+**Header は必ず Canvas の最後の sibling にすること。**
+Unity UGUI は sibling index が高いほど raycast 優先度が高いため、
+他のパネルより後に AddChild することで BackButton が確実にクリックを受け取れる。
+
+## raycastTarget 設計原則
+
+> **ボタン・インタラクティブ要素の Image だけ `raycastTarget = true`（デフォルト）。
+> それ以外（背景 Image・Text・仕切り・装飾）はすべて `raycastTarget = false` に明示する。**
+
+| 要素 | raycastTarget | 理由 |
+|------|:---:|---|
+| Button の Image (`targetGraphic`) | `true` | クリック判定に必要 |
+| 背景パネル Image | `false` | 視覚のみ。裏面への raycast を妨げない |
+| Text (Label) | `false` | テキストは入力を受け取らない |
+| ScrollRect root Image (透明) | `false` | 透明背景。Viewport Image が代わりに受け取る |
+| Viewport Image (ScrollRect 内) | `true` | 空白領域でのドラッグ・スクロールを受け取る |
+
+### コード規約
+
+```csharp
+// NG: Image を追加しただけ（raycastTarget = true のまま）
+var bg = new GameObject("BG", typeof(Image));
+
+// OK: 背景・装飾は明示的に false
+var image = go.GetComponent<Image>();
+image.raycastTarget = false;
+
+// OK: ボタン背景は true のままでよい（Button.targetGraphic として使うため）
+var button = go.AddComponent<Button>();
+button.targetGraphic = go.GetComponent<Image>(); // raycastTarget = true (default)
+```
+
+Codex にコードを生成させる際は、上記ルールをプロンプトに明記すること。
+
+## 機能一覧 (FeatureId)
+
+| Id | カテゴリ色 |
+|----|-----------|
+| LocalSave | #3A6BC8 |
+| EncryptedStorage | #3A6BC8 |
+| TextManager | #2E8B57 |
+| InputBlock | #8B3A8B |
+| Network | #8B3A3A |
+| OfflineQueue | #8B3A3A |
+| Grid | #6B4E2A |
+| UniLabButton | #6B4E2A |
+| AnimationPlayer | #6B4E2A |
+| Toast | #6B4E2A |
+| Loading | #6B4E2A |
+| BackKey | #6B4E2A |

--- a/docs/devlog/2026-03-30-sample-scene-status-display-spec.md
+++ b/docs/devlog/2026-03-30-sample-scene-status-display-spec.md
@@ -1,0 +1,300 @@
+# Sample Scene Status Display — 実装仕様
+
+## 目的
+
+各機能デモ画面に「現在の状態を視覚的に示すステータスパネル」を追加する。
+ボタンを押した結果がログだけでなく画面上の UI で確認できるようにする。
+
+---
+
+## 変更概要
+
+### 新規フィールド（`UniLabSampleScene` クラス内）
+
+```csharp
+// Status display for the currently shown feature screen.
+// Set by BuildFeatureContent_*, updated by Demo* methods.
+private Image _featureStatusImage;
+private Text  _featureStatusText;
+```
+
+### 新規定数
+
+```csharp
+private static readonly Color StatusColorNeutral  = new Color(0.12f, 0.12f, 0.18f);
+private static readonly Color StatusColorSuccess  = new Color(0.10f, 0.28f, 0.15f);
+private static readonly Color StatusColorWarning  = new Color(0.32f, 0.20f, 0.08f);
+private static readonly Color StatusColorError    = new Color(0.28f, 0.10f, 0.10f);
+```
+
+### 新規ヘルパー
+
+```csharp
+/// <summary>
+/// Adds a status display panel (140px tall) to the feature content area.
+/// Sets _featureStatusImage and _featureStatusText for later updates.
+/// </summary>
+private void AddStatusDisplay(RectTransform parent, string initialText, Color initialColor)
+```
+
+実装内容:
+- `GameObject("StatusPanel", typeof(Image))` を追加、`raycastTarget = false`
+- `anchorMin=(0,1), anchorMax=(1,1), pivot=(0.5,1), sizeDelta=(0,140)`
+- Image に initialColor を設定
+- 内部に `CreateLabel` (font 20px, TextAnchor.UpperLeft, Color.white)、padding offsetMin=(12,8) offsetMax=(-12,-8)
+- `_featureStatusImage` と `_featureStatusText` にセット
+
+```csharp
+/// <summary>Updates the status panel color and text.</summary>
+private void UpdateStatus(string text, Color color)
+{
+    if (_featureStatusImage != null) _featureStatusImage.color = color;
+    if (_featureStatusText  != null) _featureStatusText.text   = text;
+}
+```
+
+---
+
+## 各機能の変更仕様
+
+### 1. LocalSave
+
+**BuildFeatureContent_LocalSave:**
+- `AddFeatureHeader` の後、`AddStatusDisplay` (初期テキスト `RefreshLocalSaveStatus()` 相当、Neutral) を追加
+- ボタン行は既存のまま
+
+**新規プライベートメソッド `RefreshLocalSaveStatus()`:**
+```
+var loaded = LocalSave.Load<SampleSaveData>();
+if (loaded.Counter == 0 && loaded.Label == null)
+    UpdateStatus("No data saved.", StatusColorNeutral);
+else
+    UpdateStatus($"Counter : {loaded.Counter}\nLabel   : {loaded.Label}", StatusColorSuccess);
+```
+
+**DemoLocalSaveSave:** 既存ロジック後に `RefreshLocalSaveStatus()` を呼ぶ。
+
+**DemoLocalSaveDelete:** 既存ロジック後に `RefreshLocalSaveStatus()` を呼ぶ。
+
+---
+
+### 2. EncryptedStorage
+
+**BuildFeatureContent_EncryptedStorage:**
+- `AddStatusDisplay` (初期: `"demo_key: Not found"`, Error) を追加
+
+**DemoEncryptedStorage (Save & Load):**
+```
+// 既存処理後
+UpdateStatus("demo_key: ✓ Saved\nCounter : 99 / Label : secret", StatusColorSuccess);
+```
+
+**DemoEncryptedStorageDelete:**
+```
+// 既存処理後
+UpdateStatus("demo_key: — Not found", StatusColorError);
+```
+
+---
+
+### 3. TextManager
+
+**BuildFeatureContent_TextManager:**
+- `AddStatusDisplay` (初期: `"Language: JA\napp_title = [tap button]"`, Neutral) を追加
+
+**DemoTextManagerJa:**
+```
+TextManager.SetLanguage("ja");
+var text = TextManager.GetText("app_title");
+UpdateStatus($"Language : JA\napp_title = {text}", StatusColorSuccess);
+Log($"[Text] ja: app_title = {text}");
+```
+
+**DemoTextManagerEn:**
+```
+TextManager.SetLanguage("en");
+var text = TextManager.GetText("app_title");
+Log($"[Text] en: app_title = {text}");
+TextManager.SetLanguage("ja");  // restore
+UpdateStatus($"Language : EN\napp_title = {text}", StatusColorSuccess);
+```
+
+---
+
+### 4. InputBlock
+
+**BuildFeatureContent_InputBlock:**
+- `AddStatusDisplay` (初期: `"Input: Open"`, Success) を追加
+
+**DemoToggleInputBlock:**
+- 既存の toggle ロジックを維持しつつ、直後に下記を呼ぶ:
+```
+if (InputBlockManager.BlockedInput)
+    UpdateStatus($"Input: BLOCKED\nDepth: {InputBlockManager.BlockCount}", StatusColorError);
+else
+    UpdateStatus("Input: Open", StatusColorSuccess);
+```
+※ `InputBlockManager.BlockCount` が存在しない場合は depth 表示を省略。
+
+---
+
+### 5. Network
+
+**BuildFeatureContent_Network:**
+- `AddStatusDisplay` (初期: `$"Reachability: {Application.internetReachability}"`, Neutral) を追加
+
+**DemoNetworkReachability:**
+```
+var r = Application.internetReachability;
+Log($"[Network] Current: {r}");
+switch (r)
+{
+    case NetworkReachability.ReachableViaLocalAreaNetwork:
+        UpdateStatus("Reachability: WiFi ✓", StatusColorSuccess); break;
+    case NetworkReachability.ReachableViaCarrierDataNetwork:
+        UpdateStatus("Reachability: Mobile ✓", StatusColorWarning); break;
+    default:
+        UpdateStatus("Reachability: Not Reachable ✗", StatusColorError); break;
+}
+```
+
+---
+
+### 6. OfflineQueue
+
+**BuildFeatureContent_OfflineQueue:**
+- `AddStatusDisplay` (初期: `"Queue: 0 items"`, Neutral) を追加
+
+**RefreshOfflineQueueStatus (新規プライベートメソッド):**
+```
+var count = _offlineQueue.Count;
+UpdateStatus(count == 0 ? "Queue: empty" : $"Queue: {count} item(s) pending",
+             count == 0 ? StatusColorNeutral : StatusColorWarning);
+```
+
+**DemoOfflineQueueEnqueue / DemoOfflineQueueClear:**
+- 既存処理後 `RefreshOfflineQueueStatus()` を呼ぶ。
+
+**FlushOfflineQueueAsync:**
+- flush 開始時: `UpdateStatus("Flushing...", StatusColorWarning)`
+- flush 完了時: `RefreshOfflineQueueStatus()`
+
+---
+
+### 7. Grid
+
+Grid には既存のビジュアルデモ（アイテムが並ぶパネル）があるため、
+ステータスパネルは「Items: N」のカウンター表示のみ。
+
+**BuildFeatureContent_Grid:**
+- `AddStatusDisplay` (初期: `"Items: 0"`, Neutral) を追加（グリッドパネルの前）
+
+**DemoGridAddItem / DemoGridClear:**
+- 既存処理後 `UpdateStatus($"Items: {_gridChildCount}", _gridChildCount == 0 ? StatusColorNeutral : StatusColorSuccess)` を呼ぶ。
+
+---
+
+### 8. UniLabButton
+
+ボタン操作中のリアルタイム状態表示。
+
+**BuildFeatureContent_UniLabButton:**
+- `AddStatusDisplay` (初期: `"State: None"`, Neutral) を追加
+- `StateAsObservable()` の Subscribe を以下に変更:
+```csharp
+_featureDisposables.Add(
+    uniLabButton.StateAsObservable()
+        .Subscribe(state =>
+        {
+            Log($"[UniLabButton] State → {state}");
+            var (text, color) = state switch
+            {
+                ButtonState.Pressed  => ("State: Pressed",  StatusColorSuccess),
+                ButtonState.Holding  => ("State: Holding",  StatusColorWarning),
+                ButtonState.Decided  => ("State: Decided ✓", StatusColorSuccess),
+                _                    => ("State: None",      StatusColorNeutral),
+            };
+            UpdateStatus(text, color);
+        }));
+```
+※ `ButtonState` の値名は実際の enum に合わせること。
+
+---
+
+### 9. AnimationPlayer
+
+**BuildFeatureContent_AnimationPlayer:**
+- `AddStatusDisplay` (初期: `"IsPlaying: —\n(tap Setup to initialize)"`, Neutral) を追加
+
+**DemoAnimationPlayerSetup:**
+- 既存の Subscribe に加え:
+```
+UpdateStatus("IsPlaying: false\nOnPlay / OnComplete subscribed", StatusColorSuccess);
+player.OnPlay.Subscribe(_ => UpdateStatus("IsPlaying: true", StatusColorSuccess))
+    を _disposables に追加 (featureDisposables ではなく _disposables — player は _disposables.Add で管理)
+player.OnComplete.Subscribe(_ => UpdateStatus("IsPlaying: false", StatusColorNeutral))
+    を同様に追加
+```
+NOTE: `player` は DemoAnimationPlayerSetup 内のローカル変数のため、
+Subscribe を `_disposables` に追加するのは不自然。
+代わりに `_featureDisposables` に追加し、setupDone フラグで二重 setup を防ぐ。
+
+---
+
+### 10. Toast
+
+**BuildFeatureContent_Toast:**
+- `AddStatusDisplay` (初期: `"Last toast: (none)"`, Neutral) を追加
+
+**ShowToast(string message, ToastType type):**
+- 成功時: `UpdateStatus($"Last: {type}\n\"{message}\"", StatusColorSuccess)`
+- スキップ時: `UpdateStatus("⚠ _hasToastManager is disabled.\nEnable in Inspector.", StatusColorWarning)`
+
+---
+
+### 11. Loading
+
+**BuildFeatureContent_Loading:**
+- `AddStatusDisplay` (初期: `"Overlay: Hidden"`, Neutral) を追加
+
+**ShowLoadingAsync:**
+- `show` 直後: `UpdateStatus("Overlay: Visible", StatusColorWarning)`
+- `using` を抜けた後: `UpdateStatus("Overlay: Hidden", StatusColorNeutral)`
+- `catch` 内: `UpdateStatus($"Error: {exception.Message}", StatusColorError)`
+- スキップ時 (`!_hasLoadingManager`): `UpdateStatus("⚠ _hasLoadingManager is disabled.\nEnable in Inspector.", StatusColorWarning)`
+
+---
+
+### 12. BackKey
+
+**BuildFeatureContent_BackKey:**
+- `AddStatusDisplay` (初期: `"Back Key: Active"`, Success) を追加
+
+**DemoBackKeyToggleBlock:**
+- 既存処理後:
+```
+UpdateStatus(manager.IsBlocked ? "Back Key: BLOCKED" : "Back Key: Active",
+             manager.IsBlocked ? StatusColorError : StatusColorSuccess);
+```
+
+---
+
+## レイアウト規約（設計ルール）
+
+- ステータスパネルは `AddFeatureHeader` の直後、アクションボタンの前に置く
+- 高さ固定 140px（必要に応じて Content の折り返しは自動）
+- `raycastTarget = false`（インタラクティブではない）
+- 色で状態を伝える: Success=緑, Warning=橙, Error=赤, Neutral=暗色
+
+---
+
+## コーディング規約（Codex 向け）
+
+- ブロック namespace を使用 (`namespace UniLab.Sample { ... }`)
+- `{}` は if/for/foreach/switch 全てに付ける
+- 変数名の省略形は禁止 (`img` → `image`, `txt` → `text`, `go` → `gameObject`)
+  ただし `Unity GameObject 慣習の Go サフィックス` はそのまま維持する（`buttonGo` 等）
+- public メンバーには必ず `/// <summary>` を付ける
+- 非インタラクティブ Image は `raycastTarget = false`
+- Text は常に `raycastTarget = false`
+- `_featureDisposables` に Subscribe を追加する際は必ず `.Add()` で管理する


### PR DESCRIPTION
## Summary

- メニュー画面 → 機能詳細画面の2パネル切り替えナビゲーションに刷新（シーンロードなし）
- 全12機能デモ画面にステータス表示パネルを追加（ログだけでなく UI で状態を視覚化）
- 非インタラクティブな Image/Text の `raycastTarget = false` を徹底
- Header を Canvas の最終 sibling にして BackButton の raycast 優先度を確保
- namespace 再設計時の Unity `.meta` ファイルを追加

## Changes

### Navigation
- `FeatureId` enum + `ShowMenu()` / `ShowFeature(FeatureId)` の2パネル切り替え
- Back ボタン（左上）でメニューへ戻る
- `_featureDisposables` で画面遷移ごとに Subscribe をクリア

### Status Display (全12機能)
- 各機能画面に 140px のステータスパネルを追加
- Success=緑 / Warning=橙 / Error=赤 / Neutral=暗色で状態を色分け
- UniLabButton は `StateAsObservable()` でリアルタイム状態変化を表示

### raycastTarget 設計
- `CreatePanel` / `CreateLabel` ヘルパーで一括 `raycastTarget = false`
- ScrollView root Image も `false`（Viewport Image がドラッグ受け口を担う）
- Button の `targetGraphic` Image のみ `true`（デフォルト）

## Test plan

- [ ] メニュー画面が起動時に表示される
- [ ] 各メニューボタンをタップして機能詳細画面に遷移できる
- [ ] Back ボタンでメニューに戻れる
- [ ] 各デモボタンを押すとステータスパネルが更新される
- [ ] UniLabButton のステータスがリアルタイムに変化する

🤖 Generated with [Claude Code](https://claude.com/claude-code)