### PR TITLE
feat: AssetVault CDN ランタイム（実行時バージョン解決）と EditMode テストを追加

### DIFF
--- a/Assets/Editor/Tests/AssetVault.meta
+++ b/Assets/Editor/Tests/AssetVault.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8b219a75a445246d9a027964df24ce02
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs
@@ -27,23 +27,23 @@ namespace UniLab.Tests.EditMode.AssetVault
         }
 
         /// <summary>
-        /// 既定の環境名が prod であることを検証します。
+        /// 既定の基底 URL が null であることを検証します。
         /// </summary>
         [Test]
-        public void Environment_DefaultValue_IsProd()
+        public void BaseUrl_DefaultValue_IsNull()
         {
-            Assert.AreEqual("prod", AssetVaultRuntime.Environment);
+            Assert.IsNull(AssetVaultRuntime.BaseUrl);
         }
 
         /// <summary>
-        /// Environment の set と get が反映されることを検証します。
+        /// BaseUrl の set と get が反映されることを検証します。
         /// </summary>
         [Test]
-        public void Environment_SetValue_ReturnsAssignedValue()
+        public void BaseUrl_SetValue_ReturnsAssignedValue()
         {
-            AssetVaultRuntime.Environment = "staging";
+            AssetVaultRuntime.BaseUrl = "https://dev1.xxx.xxx/app";
 
-            Assert.AreEqual("staging", AssetVaultRuntime.Environment);
+            Assert.AreEqual("https://dev1.xxx.xxx/app", AssetVaultRuntime.BaseUrl);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace UniLab.Tests.EditMode.AssetVault
 
         private static void ResetRuntime()
         {
-            AssetVaultRuntime.Environment = "prod";
+            AssetVaultRuntime.BaseUrl = null;
             AssetVaultRuntime.ContentPath = null;
         }
     }

--- a/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs
@@ -1,0 +1,66 @@
+using NUnit.Framework;
+using UniLab.AssetVault;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// AssetVaultRuntime の単体テストです。
+    /// </summary>
+    public class AssetVaultRuntimeTest
+    {
+        /// <summary>
+        /// 各テスト前に静的状態を既定値へ戻します。
+        /// </summary>
+        [SetUp]
+        public void SetUp()
+        {
+            ResetRuntime();
+        }
+
+        /// <summary>
+        /// 各テスト後に静的状態を既定値へ戻します。
+        /// </summary>
+        [TearDown]
+        public void TearDown()
+        {
+            ResetRuntime();
+        }
+
+        /// <summary>
+        /// 既定の環境名が prod であることを検証します。
+        /// </summary>
+        [Test]
+        public void Environment_DefaultValue_IsProd()
+        {
+            Assert.AreEqual("prod", AssetVaultRuntime.Environment);
+        }
+
+        /// <summary>
+        /// Environment の set と get が反映されることを検証します。
+        /// </summary>
+        [Test]
+        public void Environment_SetValue_ReturnsAssignedValue()
+        {
+            AssetVaultRuntime.Environment = "staging";
+
+            Assert.AreEqual("staging", AssetVaultRuntime.Environment);
+        }
+
+        /// <summary>
+        /// ContentPath の set と get が反映されることを検証します。
+        /// </summary>
+        [Test]
+        public void ContentPath_SetValue_ReturnsAssignedValue()
+        {
+            AssetVaultRuntime.ContentPath = "01J9Z8K3Q4XR";
+
+            Assert.AreEqual("01J9Z8K3Q4XR", AssetVaultRuntime.ContentPath);
+        }
+
+        private static void ResetRuntime()
+        {
+            AssetVaultRuntime.Environment = "prod";
+            AssetVaultRuntime.ContentPath = null;
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultRuntimeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4545218f6ba6446a848fc25173ff41f

--- a/Assets/Editor/Tests/AssetVault/AssetVaultTest.asmdef
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultTest.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "AssetVaultTest",
+    "rootNamespace": "",
+    "references": [
+        "UniLab.AssetVault",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+    ],
+    "includePlatforms": [ "Editor" ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [ "nunit.framework.dll" ],
+    "autoReferenced": false,
+    "defineConstraints": [ "UNITY_INCLUDE_TESTS" ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultTest.asmdef.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultTest.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 840dba2be55a5487393956fd41337f1d
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/Tests/AssetVault/ContentVersionInfoTest.cs
+++ b/Assets/Editor/Tests/AssetVault/ContentVersionInfoTest.cs
@@ -1,0 +1,23 @@
+using NUnit.Framework;
+using UniLab.AssetVault;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// ContentVersionInfo の単体テストです。
+    /// </summary>
+    public class ContentVersionInfoTest
+    {
+        /// <summary>
+        /// コンストラクタ引数が各プロパティに保持されることを検証します。
+        /// </summary>
+        [Test]
+        public void Constructor_SetsContentVersionAndPath()
+        {
+            var contentVersionInfo = new ContentVersionInfo("00052", "01J9Z8K3Q4XR");
+
+            Assert.AreEqual("00052", contentVersionInfo.ContentVersion);
+            Assert.AreEqual("01J9Z8K3Q4XR", contentVersionInfo.Path);
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/ContentVersionInfoTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/ContentVersionInfoTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b18d89608e5f144d99d4e2974ee1279b

--- a/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs
+++ b/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using NUnit.Framework;
+using UniLab.AssetVault;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// RemoteContentVersionResolver の単体テストです。
+    /// </summary>
+    public class RemoteContentVersionResolverTest
+    {
+        /// <summary>
+        /// 基底 URL 末尾のスラッシュが重複せず version.json の URL が作られることを検証します。
+        /// </summary>
+        [Test]
+        public void ResolveAsync_NormalizesUrl_WhenBaseUrlEndsWithSlash()
+        {
+            string requestedUrl = null;
+            var resolver = new RemoteContentVersionResolver(
+                "https://cdn/app/",
+                "prod",
+                (url, cancellationToken) =>
+                {
+                    requestedUrl = url;
+                    return UniTask.FromResult("{\"contentVersion\":\"00052\",\"path\":\"01J9Z8K3Q4XR\"}");
+                });
+
+            resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual("https://cdn/app/prod/version.json", requestedUrl);
+        }
+
+        /// <summary>
+        /// 正常な JSON からコンテンツ版情報を返すことを検証します。
+        /// </summary>
+        [Test]
+        public void ResolveAsync_ReturnsContentVersion_WhenJsonValid()
+        {
+            var resolver = new RemoteContentVersionResolver(
+                "https://cdn/app",
+                "prod",
+                (url, cancellationToken) => UniTask.FromResult("{\"contentVersion\":\"00052\",\"path\":\"01J9Z8K3Q4XR\"}"));
+
+            var contentVersionInfo = resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult();
+
+            Assert.AreEqual("00052", contentVersionInfo.ContentVersion);
+            Assert.AreEqual("01J9Z8K3Q4XR", contentVersionInfo.Path);
+        }
+
+        /// <summary>
+        /// 取得処理の AssetVaultException が二重ラップされないことを検証します。
+        /// </summary>
+        [Test]
+        public void ResolveAsync_ThrowsSameAssetVaultException_WhenFetcherFails()
+        {
+            var expectedException = new AssetVaultException("failed");
+            var resolver = new RemoteContentVersionResolver(
+                "https://cdn/app",
+                "prod",
+                (url, cancellationToken) => throw expectedException);
+
+            var actualException = Assert.Throws<AssetVaultException>(
+                () => resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult());
+
+            Assert.AreSame(expectedException, actualException);
+        }
+
+        /// <summary>
+        /// 不正な JSON が AssetVaultException に変換されることを検証します。
+        /// </summary>
+        [Test]
+        public void ResolveAsync_ThrowsAssetVaultException_WhenJsonInvalid()
+        {
+            var resolver = new RemoteContentVersionResolver(
+                "https://cdn/app",
+                "prod",
+                (url, cancellationToken) => UniTask.FromResult("not json"));
+
+            Assert.Throws<AssetVaultException>(
+                () => resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult());
+        }
+
+        /// <summary>
+        /// キャンセル例外が AssetVaultException に変換されないことを検証します。
+        /// </summary>
+        [Test]
+        public void ResolveAsync_ThrowsOperationCanceledException_WhenFetcherCanceled()
+        {
+            var resolver = new RemoteContentVersionResolver(
+                "https://cdn/app",
+                "prod",
+                (url, cancellationToken) => throw new OperationCanceledException());
+
+            Assert.Throws<OperationCanceledException>(
+                () => resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult());
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs
+++ b/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs
@@ -12,15 +12,14 @@ namespace UniLab.Tests.EditMode.AssetVault
     public class RemoteContentVersionResolverTest
     {
         /// <summary>
-        /// 基底 URL 末尾のスラッシュが重複せず version.json の URL が作られることを検証します。
+        /// 基底 URL から version.json の URL が作られることを検証します。
         /// </summary>
         [Test]
-        public void ResolveAsync_NormalizesUrl_WhenBaseUrlEndsWithSlash()
+        public void ResolveAsync_BuildsVersionJsonUrl_FromBaseUrl()
         {
             string requestedUrl = null;
             var resolver = new RemoteContentVersionResolver(
                 "https://cdn/app/",
-                "prod",
                 (url, cancellationToken) =>
                 {
                     requestedUrl = url;
@@ -29,7 +28,7 @@ namespace UniLab.Tests.EditMode.AssetVault
 
             resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult();
 
-            Assert.AreEqual("https://cdn/app/prod/version.json", requestedUrl);
+            Assert.AreEqual("https://cdn/app/version.json", requestedUrl);
         }
 
         /// <summary>
@@ -40,7 +39,6 @@ namespace UniLab.Tests.EditMode.AssetVault
         {
             var resolver = new RemoteContentVersionResolver(
                 "https://cdn/app",
-                "prod",
                 (url, cancellationToken) => UniTask.FromResult("{\"contentVersion\":\"00052\",\"path\":\"01J9Z8K3Q4XR\"}"));
 
             var contentVersionInfo = resolver.ResolveAsync(CancellationToken.None).GetAwaiter().GetResult();
@@ -58,7 +56,6 @@ namespace UniLab.Tests.EditMode.AssetVault
             var expectedException = new AssetVaultException("failed");
             var resolver = new RemoteContentVersionResolver(
                 "https://cdn/app",
-                "prod",
                 (url, cancellationToken) => throw expectedException);
 
             var actualException = Assert.Throws<AssetVaultException>(
@@ -75,7 +72,6 @@ namespace UniLab.Tests.EditMode.AssetVault
         {
             var resolver = new RemoteContentVersionResolver(
                 "https://cdn/app",
-                "prod",
                 (url, cancellationToken) => UniTask.FromResult("not json"));
 
             Assert.Throws<AssetVaultException>(
@@ -90,7 +86,6 @@ namespace UniLab.Tests.EditMode.AssetVault
         {
             var resolver = new RemoteContentVersionResolver(
                 "https://cdn/app",
-                "prod",
                 (url, cancellationToken) => throw new OperationCanceledException());
 
             Assert.Throws<OperationCanceledException>(

--- a/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/RemoteContentVersionResolverTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ac3b809e2292e47ac86045f17b4077ea

--- a/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
@@ -1,0 +1,18 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// Addressables の RemoteLoadPath に埋めた実行時トークン {UniLab.AssetVault.AssetVaultRuntime.Environment} / {UniLab.AssetVault.AssetVaultRuntime.ContentPath} が参照する静的状態です。IAssetVaultService.InitializeAsync の前にアプリ層がセットします。
+    /// </summary>
+    public static class AssetVaultRuntime
+    {
+        /// <summary>
+        /// アプリ層が IAssetVaultService.InitializeAsync の前にセットし、RemoteLoadPath の環境セグメントを切り替えるために使われます。
+        /// </summary>
+        public static string Environment { get; set; } = "prod";
+
+        /// <summary>
+        /// アプリ層が IContentVersionResolver の解決結果またはデバッグ上書きから IAssetVaultService.InitializeAsync の前にセットし、RemoteLoadPath のコンテンツ版パスセグメントに使われます。
+        /// </summary>
+        public static string ContentPath { get; set; } = null;
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
@@ -1,17 +1,17 @@
 namespace UniLab.AssetVault
 {
     /// <summary>
-    /// Addressables の RemoteLoadPath に埋めた実行時トークン {UniLab.AssetVault.AssetVaultRuntime.Environment} / {UniLab.AssetVault.AssetVaultRuntime.ContentPath} が参照する静的状態です。IAssetVaultService.InitializeAsync の前にアプリ層がセットします。
+    /// Addressables の RemoteLoadPath に埋めた実行時トークン {UniLab.AssetVault.AssetVaultRuntime.BaseUrl} / {UniLab.AssetVault.AssetVaultRuntime.ContentPath} が参照する静的状態です。IAssetVaultService.InitializeAsync の前にアプリ層がセットします。
     /// </summary>
     public static class AssetVaultRuntime
     {
         /// <summary>
-        /// アプリ層が IAssetVaultService.InitializeAsync の前にセットし、RemoteLoadPath の環境セグメントを切り替えるために使われます。
+        /// 環境ごとのホスト込み基底 URL です（例 https://dev1.xxx.xxx/app）。env から URL へのマッピングはアプリ config が持ちます。
         /// </summary>
-        public static string Environment { get; set; } = "prod";
+        public static string BaseUrl { get; set; } = null;
 
         /// <summary>
-        /// アプリ層が IContentVersionResolver の解決結果またはデバッグ上書きから IAssetVaultService.InitializeAsync の前にセットし、RemoteLoadPath のコンテンツ版パスセグメントに使われます。
+        /// version.json の path です。RemoteLoadPath の不透明な版セグメントに使われます。
         /// </summary>
         public static string ContentPath { get; set; } = null;
     }

--- a/Assets/UniLab/AssetVault/AssetVaultRuntime.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultRuntime.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 161e36a111cc4406485c092cb3f00a0e

--- a/Assets/UniLab/AssetVault/Interface/IContentVersionResolver.cs
+++ b/Assets/UniLab/AssetVault/Interface/IContentVersionResolver.cs
@@ -1,0 +1,16 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// version.json 等から現在のコンテンツ版を解決します。実装はアプリ層や BFF が差し替え可能です。IAssetVaultService.InitializeAsync の前に呼び、結果を AssetVaultRuntime にセットします。
+    /// </summary>
+    public interface IContentVersionResolver
+    {
+        /// <summary>
+        /// 現在有効なコンテンツ版を非同期で解決します。
+        /// </summary>
+        UniTask<ContentVersionInfo> ResolveAsync(CancellationToken cancellationToken);
+    }
+}

--- a/Assets/UniLab/AssetVault/Interface/IContentVersionResolver.cs.meta
+++ b/Assets/UniLab/AssetVault/Interface/IContentVersionResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ee04139d82e274e098fd71b718332127

--- a/Assets/UniLab/AssetVault/Model/ContentVersionInfo.cs
+++ b/Assets/UniLab/AssetVault/Model/ContentVersionInfo.cs
@@ -1,0 +1,27 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// version.json の中身を表します。ContentVersion は文字列一致で版変更を判定する内部版 ID、Path は URL セグメントとして使う公開パスです。
+    /// </summary>
+    public readonly struct ContentVersionInfo
+    {
+        /// <summary>
+        /// 内部版 ID を取得します。文字列一致で版変更を判定し、順序比較には使いません。
+        /// </summary>
+        public string ContentVersion { get; }
+
+        /// <summary>
+        /// RemoteLoadPath の ContentPath に使う、公開 URL の不透明セグメントを取得します。
+        /// </summary>
+        public string Path { get; }
+
+        /// <summary>
+        /// version.json から解決したコンテンツ版情報を作成します。
+        /// </summary>
+        public ContentVersionInfo(string contentVersion, string path)
+        {
+            ContentVersion = contentVersion;
+            Path = path;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Model/ContentVersionInfo.cs.meta
+++ b/Assets/UniLab/AssetVault/Model/ContentVersionInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ebee76c0269bb474bbb7c885d8f51626

--- a/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
+++ b/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
@@ -12,17 +12,25 @@ namespace UniLab.AssetVault
     public sealed class RemoteContentVersionResolver : IContentVersionResolver
     {
         private readonly string _url;
-        private readonly int _requestTimeoutSeconds;
+        private readonly Func<string, CancellationToken, UniTask<string>> _fetchAsync;
 
         /// <summary>
         /// コンテンツ配信の基底 URL と環境名から version.json の URL を作成します。
         /// requestTimeoutSeconds は起動必須の取得が無応答の CDN で無限に待たないための上限です。
         /// </summary>
         public RemoteContentVersionResolver(string contentBaseUrl, string environment, int requestTimeoutSeconds = 15)
+            : this(contentBaseUrl, environment, CreateUnityWebRequestFetcher(requestTimeoutSeconds))
+        {
+        }
+
+        /// <summary>
+        /// コンテンツ配信の基底 URL と環境名、version.json 取得処理から resolver を作成します。
+        /// </summary>
+        public RemoteContentVersionResolver(string contentBaseUrl, string environment, Func<string, CancellationToken, UniTask<string>> fetchAsync)
         {
             var normalizedContentBaseUrl = contentBaseUrl.TrimEnd('/');
             _url = $"{normalizedContentBaseUrl}/{environment}/version.json";
-            _requestTimeoutSeconds = requestTimeoutSeconds;
+            _fetchAsync = fetchAsync;
         }
 
         /// <summary>
@@ -32,23 +40,37 @@ namespace UniLab.AssetVault
         {
             try
             {
-                using (var request = UnityWebRequest.Get(_url))
+                var json = await _fetchAsync(_url, cancellationToken);
+                var contentVersionJson = JsonUtility.FromJson<ContentVersionJson>(json);
+                if (contentVersionJson == null)
                 {
-                    request.timeout = _requestTimeoutSeconds;
-                    await request.SendWebRequest().ToUniTask(cancellationToken: cancellationToken);
-                    if (request.result != UnityWebRequest.Result.Success)
-                    {
-                        throw new AssetVaultException($"Failed to resolve content version from {_url}. Error: {request.error}");
-                    }
-
-                    var dto = JsonUtility.FromJson<ContentVersionJson>(request.downloadHandler.text);
-                    return new ContentVersionInfo(dto.contentVersion, dto.path);
+                    throw new AssetVaultException($"Failed to resolve content version from {_url}. Invalid version json.");
                 }
+
+                return new ContentVersionInfo(contentVersionJson.contentVersion, contentVersionJson.path);
             }
             catch (Exception exception) when (exception is not OperationCanceledException)
             {
                 throw AssetVaultOperationGuard.ToAssetVaultException(exception, $"Failed to resolve content version from {_url}.");
             }
+        }
+
+        private static Func<string, CancellationToken, UniTask<string>> CreateUnityWebRequestFetcher(int requestTimeoutSeconds)
+        {
+            return async (url, cancellationToken) =>
+            {
+                using (var request = UnityWebRequest.Get(url))
+                {
+                    request.timeout = requestTimeoutSeconds;
+                    await request.SendWebRequest().ToUniTask(cancellationToken: cancellationToken);
+                    if (request.result != UnityWebRequest.Result.Success)
+                    {
+                        throw new AssetVaultException($"Failed to resolve content version from {url}. Error: {request.error}");
+                    }
+
+                    return request.downloadHandler.text;
+                }
+            };
         }
 
         [Serializable]

--- a/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
+++ b/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
@@ -15,21 +15,20 @@ namespace UniLab.AssetVault
         private readonly Func<string, CancellationToken, UniTask<string>> _fetchAsync;
 
         /// <summary>
-        /// コンテンツ配信の基底 URL と環境名から version.json の URL を作成します。
+        /// 解決済みの基底 URL から version.json の URL を作成します。
         /// requestTimeoutSeconds は起動必須の取得が無応答の CDN で無限に待たないための上限です。
         /// </summary>
-        public RemoteContentVersionResolver(string contentBaseUrl, string environment, int requestTimeoutSeconds = 15)
-            : this(contentBaseUrl, environment, CreateUnityWebRequestFetcher(requestTimeoutSeconds))
+        public RemoteContentVersionResolver(string baseUrl, int requestTimeoutSeconds = 15)
+            : this(baseUrl, CreateUnityWebRequestFetcher(requestTimeoutSeconds))
         {
         }
 
         /// <summary>
-        /// コンテンツ配信の基底 URL と環境名、version.json 取得処理から resolver を作成します。
+        /// 解決済みの基底 URL と version.json 取得処理から resolver を作成します。
         /// </summary>
-        public RemoteContentVersionResolver(string contentBaseUrl, string environment, Func<string, CancellationToken, UniTask<string>> fetchAsync)
+        public RemoteContentVersionResolver(string baseUrl, Func<string, CancellationToken, UniTask<string>> fetchAsync)
         {
-            var normalizedContentBaseUrl = contentBaseUrl.TrimEnd('/');
-            _url = $"{normalizedContentBaseUrl}/{environment}/version.json";
+            _url = $"{baseUrl.TrimEnd('/')}/version.json";
             _fetchAsync = fetchAsync;
         }
 

--- a/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
+++ b/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.Networking;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// CDN 上の version.json から現在のコンテンツ版を解決する HTTP 実装です。
+    /// </summary>
+    public sealed class RemoteContentVersionResolver : IContentVersionResolver
+    {
+        private readonly string _url;
+        private readonly int _requestTimeoutSeconds;
+
+        /// <summary>
+        /// コンテンツ配信の基底 URL と環境名から version.json の URL を作成します。
+        /// requestTimeoutSeconds は起動必須の取得が無応答の CDN で無限に待たないための上限です。
+        /// </summary>
+        public RemoteContentVersionResolver(string contentBaseUrl, string environment, int requestTimeoutSeconds = 15)
+        {
+            var normalizedContentBaseUrl = contentBaseUrl.TrimEnd('/');
+            _url = $"{normalizedContentBaseUrl}/{environment}/version.json";
+            _requestTimeoutSeconds = requestTimeoutSeconds;
+        }
+
+        /// <summary>
+        /// version.json を取得し、RemoteLoadPath に使うコンテンツ版情報を返します。
+        /// </summary>
+        public async UniTask<ContentVersionInfo> ResolveAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                using (var request = UnityWebRequest.Get(_url))
+                {
+                    request.timeout = _requestTimeoutSeconds;
+                    await request.SendWebRequest().ToUniTask(cancellationToken: cancellationToken);
+                    if (request.result != UnityWebRequest.Result.Success)
+                    {
+                        throw new AssetVaultException($"Failed to resolve content version from {_url}. Error: {request.error}");
+                    }
+
+                    var dto = JsonUtility.FromJson<ContentVersionJson>(request.downloadHandler.text);
+                    return new ContentVersionInfo(dto.contentVersion, dto.path);
+                }
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                throw AssetVaultOperationGuard.ToAssetVaultException(exception, $"Failed to resolve content version from {_url}.");
+            }
+        }
+
+        [Serializable]
+        private class ContentVersionJson
+        {
+            /// <summary>
+            /// 文字列一致で版変更を判定する内部版 ID です。
+            /// </summary>
+            public string contentVersion;
+
+            /// <summary>
+            /// RemoteLoadPath の ContentPath に使う公開 URL の不透明セグメントです。
+            /// </summary>
+            public string path;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs.meta
+++ b/Assets/UniLab/AssetVault/RemoteContentVersionResolver.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d4f0496b39f6b465490624b2b478d8a6

--- a/Assets/UniLab/AssetVault/Sample/AssetVaultSampleBootstrap.cs
+++ b/Assets/UniLab/AssetVault/Sample/AssetVaultSampleBootstrap.cs
@@ -39,7 +39,7 @@ namespace UniLab.AssetVault.Sample
 
         private static void EnsureEventSystem()
         {
-            if (FindFirstObjectByType<EventSystem>() != null)
+            if (FindAnyObjectByType<EventSystem>() != null)
             {
                 return;
             }

--- a/docs/design-unilab-asset-cdn.md
+++ b/docs/design-unilab-asset-cdn.md
@@ -22,11 +22,11 @@ Addressables の `RemoteLoadPath` は「ビルド時に焼かれて固定」で�
 
 ## CDN URL 規約
 
-基点を `https://<cdn-host>/app/` とした場合の配置:
+環境（dev/staging/prod）は**パスの一区切りではなく、ホストごと変わる**運用が一般的（`https://dev1.xxx.xxx/app/` ⇄ `https://cdn.xxx.xxx/app/`）。そこで**環境はホスト込みの base URL（`BaseUrl`）として表し**、版だけをパスセグメントにする。
 
 ```
-https://<cdn-host>/app/<env>/version.json              ← 固定名・可変・短TTL（唯一の入口）
-https://<cdn-host>/app/<env>/<token>/[BuildTarget]/
+{BaseUrl}/version.json                       ← 固定名・可変・短TTL（版の入口）
+{BaseUrl}/<token>/[BuildTarget]/
         ├── catalog_<id>.json     ← コンテンツカタログ
         ├── catalog_<id>.hash     ← 更新検知用（ランタイムが hash をポーリング）
         └── <group>_<contentHash>.bundle ...
@@ -34,15 +34,81 @@ https://<cdn-host>/app/<env>/<token>/[BuildTarget]/
 
 | 階層 | 意味 | 性質 |
 |---|---|---|
-| `<env>` | dev / staging / prod | 実行時トークン（既定 prod、デバッグで上書き可） |
+| `BaseUrl` | 環境ごとのホスト込み基底（`https://dev1.xxx.xxx/app` 等） | 実行時トークン。env → URL のマッピングは**アプリ config が持つ**（AssetVault はホストを知らない） |
 | `version.json` | アクティブなコンテンツ版を指す可変ファイル | **固定名**。アプリが事前知識なしで最初に取得 |
 | `<token>` | コンテンツ版の**公開パスセグメント** | **不透明トークン**（ULID 等）。推測不能 |
 | `[BuildTarget]` | プラットフォーム | ビルド時トークンで自動展開 |
 
-アプリに焼く RemoteLoadPath（“形”だけ。版・環境は実行時トークン）:
+アプリに焼く RemoteLoadPath（“形”だけ。可変部は実行時トークン）:
 
 ```
-https://<cdn-host>/app/{UniLab.AssetVault.AssetVaultRuntime.Environment}/{UniLab.AssetVault.AssetVaultRuntime.ContentPath}/[BuildTarget]
+{UniLab.AssetVault.AssetVaultRuntime.BaseUrl}/{UniLab.AssetVault.AssetVaultRuntime.ContentPath}/[BuildTarget]
+```
+
+- `BaseUrl` をホスト込みにしたことで、**サブドメイン違い・別 CDN・別パス・ポート違い**まで吸収できる。「同一ホスト内で env を分けたい」場合は BaseUrl の中に `/<env>/` を含めればよく、設計を狭めない
+- URL の可変部（host/env と版）はすべて `AssetVaultRuntime`（コード）に集約。Profile に固定で残るのは `[BuildTarget]` だけ（プラットフォーム解決は Addressables に任せ、手動マッピングしない）
+
+---
+
+## 配置 URL と 読み込み URL の決定
+
+「どこに置くか（配置）」と「どこから読むか（読み込み）」は別工程で、最終的に**同じ URL を指す**必要がある。両者を同期させるのが `version.json` と `BaseUrl` である。
+
+### A. 配置 URL（ビルド → アップロード）
+
+1. **Addressables ビルド**：`RemoteBuildPath`（例 `ServerData/[BuildTarget]/`）に catalog と bundle を出力。**bundle のファイル名はここで確定**（コンテンツハッシュ付き、Addressables が決める）
+2. **CDN へアップロード（運用/CI が決める）**：
+   - catalog + bundle → `{BaseUrl}/<token>/[BuildTarget]/`
+   - `version.json` → `{BaseUrl}/version.json`（「どの版か」を読み込み側へ伝える入口）
+
+| 部品 | 決める人 |
+|---|---|
+| `BaseUrl`（ホスト＝env） | 運用（env ごとのホスト） |
+| 版フォルダ名（`<token>`） | リリース運用（不透明トークン。新版ごとに新フォルダ） |
+| `[BuildTarget]` / bundle 名 | Addressables（ビルドが自動生成） |
+
+### B. 読み込み URL（ランタイム）
+
+**2系統に分かれる。**
+
+- **(1) 版チェック URL ＝ コードが組む**
+  ```
+  {BaseUrl}/version.json
+  ```
+  - `BaseUrl` は env からアプリ config で解決。**`[BuildTarget]` は付かない**（版はプラットフォーム共通）。`ContentPath` もまだ無い
+  - Addressables のトークンとは無関係。`InitializeAsync` の前に素の `UnityWebRequest` で取得する
+  - 結果 `{ contentVersion, path }` を得る
+
+- **(2) catalog/bundle URL ＝ Addressables が組む**
+  ```
+  {BaseUrl}/{ContentPath}/[BuildTarget]/<bundleファイル名>
+  ```
+  - `BaseUrl` / `ContentPath` = コードが `AssetVaultRuntime` にセット（`ContentPath` = version.json の `path`）
+  - `[BuildTarget]` = Addressables 自動、`<bundleファイル名>` = catalog から解決（アドレス→bundle）
+
+### C. 配置 = 読み込み が一致する条件（肝）
+
+読み込み URL は配置 URL と**完全一致**しないと 404 になる。一致の担保：
+
+| 要素 | 配置（アップロード） | 読み込み（ランタイム） | 一致のさせ方 |
+|---|---|---|---|
+| ホスト | アップロード先ホスト | アプリ config の `BaseUrl` | env ごとに両者を揃える |
+| 版フォルダ | アップした `<token>` | `version.json` の `path` | **version.json が橋渡し** |
+| プラットフォーム/ファイル名 | Addressables ビルド出力 | Addressables が catalog から解決 | Addressables が両側同一規則 |
+
+### D. 具体例（env=dev1 / iOS / 版 01J9…）
+
+```
+配置（CI）:
+  build  → ServerData/iOS/ に catalog+bundle
+  upload → https://dev1.xxx.xxx/app/01J9Z8K3Q4XR/iOS/
+  update → https://dev1.xxx.xxx/app/version.json = { path:"01J9Z8K3Q4XR" }
+
+読み込み（アプリ）:
+  config: dev1 → BaseUrl=https://dev1.xxx.xxx/app
+  GET    https://dev1.xxx.xxx/app/version.json → path=01J9Z8K3Q4XR
+  set    AssetVaultRuntime.BaseUrl / ContentPath
+  Addressables → https://dev1.xxx.xxx/app/01J9Z8K3Q4XR/iOS/catalog_*.json + *.bundle
 ```
 
 ---
@@ -55,6 +121,8 @@ https://<cdn-host>/app/{UniLab.AssetVault.AssetVaultRuntime.Environment}/{UniLab
   "path": "01J9Z8K3Q4XR"
 }
 ```
+
+取得 URL は `{BaseUrl}/version.json`（プラットフォーム非依存のため `[BuildTarget]` を付けない）。`IContentVersionResolver` がコードで組み立てる。
 
 | フィールド | 用途 | 比較方法 |
 |---|---|---|
@@ -77,22 +145,24 @@ sequenceDiagram
     participant RT as AssetVaultRuntime（static）
     participant AV as IAssetVaultService
 
-    App->>Gate: バージョンチェック（任意。ソースは pointer 任意項目 / BFF / 無効）
+    App->>App: env 決定（既定 prod / デバッグ上書き）→ config で env→BaseUrl 解決
+    App->>Gate: バージョンチェック（任意。ソースは version.json 任意項目 / BFF / 無効）
     Gate-->>App: 通過 or 強制アプデ画面へ
-    App->>Res: version.json を取得
+    App->>Res: {BaseUrl}/version.json を取得
     Res-->>App: { contentVersion, path }
     Note over App,RT: デバッグ上書きがあればそれを優先
-    App->>RT: Environment / ContentPath をセット
+    App->>RT: BaseUrl / ContentPath をセット
     App->>AV: InitializeAsync(ct)
-    AV-->>App: …/<env>/<token>/[BuildTarget]/catalog を取得して Ready
+    AV-->>App: {BaseUrl}/<token>/[BuildTarget]/catalog を取得して Ready
     App->>AV: CheckForUpdatesAsync / GetDownloadSizeAsync / DownloadAsync
 ```
 
-1. （任意）強制アプデゲートを通す
-2. `version.json` を取得し `contentVersion` / `path` を得る
-3. コンテンツ版を決定（**デバッグ上書き ＞ version.json** の優先度）
-4. `AssetVaultRuntime.Environment` / `ContentPath` をセット
-5. `InitializeAsync` → 解決済み URL のカタログを読む。以降は既存の差分DLフロー
+1. **env を決定**（既定 prod / デバッグ上書き）→ アプリ config で **env→BaseUrl** を解決
+2. （任意）強制アプデゲートを通す
+3. `{BaseUrl}/version.json` を取得し `contentVersion` / `path` を得る
+4. コンテンツ版を決定（**デバッグ上書き ＞ version.json** の優先度）
+5. `AssetVaultRuntime.BaseUrl` / `ContentPath` をセット
+6. `InitializeAsync` → 解決済み URL のカタログを読む。以降は既存の差分DLフロー
 
 ---
 
@@ -112,13 +182,19 @@ sequenceDiagram
 
 ---
 
-## デバッグでの呼び先変更
+## デバッグでの呼び先変更（版違い・別環境のロード）
 
-`AssetVaultRuntime.Environment` / `ContentPath` は単なる静的プロパティで、解決ロジックが **「デバッグ上書き ＞ version.json」** の優先度を持つ。これにより開発/QA ビルドで:
+`AssetVaultRuntime.BaseUrl` / `ContentPath` は単なる静的プロパティで、解決ロジックが **「デバッグ上書き ＞ version.json」** の優先度を持つ。`InitializeAsync` の前にこれらを上書きすれば、**version.json が指す版とは別の版・別環境を読み込める**（QA で特定版を狙ってテストする等）。
 
-- 任意の `ContentPath`（非対応版含む）を直接指定して読む
-- `Environment` を staging / dev に切替（prod アプリで staging アセットを見る）。既存 `AssetVaultProfileSwitcher` / `EnvironmentConfig`（UniLab.Debug）と連動
-- 完全に任意 URL へ向けたい場合のみ `Addressables.InternalIdTransformFunc` で書き換え
+- **同一ホストの版違い** → `ContentPath` だけ上書き（例：旧版 `00050` や未公開の事前ステージ版を指定）
+- **別環境の版** → `BaseUrl` ＋ `ContentPath` を上書き（prod アプリで dev1/staging のアセットを見る）。既存 `AssetVaultProfileSwitcher` / `EnvironmentConfig`（UniLab.Debug）と連動
+- **完全に任意 URL** → `Addressables.InternalIdTransformFunc` で書き換え（最終手段）
+
+### 成立条件
+
+1. **`InitializeAsync` の前にセットする**。カタログ URL がトークンを使うため、初期化後の書き換えはロード済みカタログに反映されない。デバッグ上書きは「version.json 解決をスキップして直接セット」の形にする
+2. **対象版が CDN に存在する**こと（アップ済みなら旧版・未公開版でも可）
+3. **互換性は別問題**：対象版のコンテンツが今のアプリに無いコード/シェーダーに依存していると、ロード時に失敗し得る（＝版違いの本質的制約。純データ版なら問題なし）
 
 ---
 
@@ -190,10 +266,12 @@ sequenceDiagram
 
 | 追加 | 種別 | 責務 |
 |---|---|---|
-| `AssetVaultRuntime` | runtime（static） | `static string Environment` / `static string ContentPath`。`InitializeAsync` 前にアプリ層がセット。RemoteLoadPath の実行時トークンが参照 |
-| `IContentVersionResolver` | runtime（抽象） | `version.json` を取得して版を返す。実装はアプリ層 / BFF。デバッグ上書きの優先度もここで解決 |
+| `AssetVaultRuntime` | runtime（static） | `static string BaseUrl`（ホスト込み基底）/ `static string ContentPath`（版セグメント）。`InitializeAsync` 前にアプリ層がセット。RemoteLoadPath の実行時トークンが参照 |
+| `IContentVersionResolver` | runtime（抽象） | 解決済み `BaseUrl` 配下の `version.json` を取得して版を返す。実装はアプリ層 / BFF。デバッグ上書きの優先度もここで解決 |
+| `RemoteContentVersionResolver` | runtime（既定実装） | `{BaseUrl}/version.json` を `UnityWebRequest`（タイムアウト付き）で取得・パース。取得処理は注入可能でテスタブル |
 
-- 既存の `IAssetVaultService` / 状態機械 / 差分DL / `IAssetScope` は**不変**。起動シーケンスに「版解決 → 静的プロパティ設定 → Init」の1ステップを足すだけ
+- 既存の `IAssetVaultService` / 状態機械 / 差分DL / `IAssetScope` は**不変**。起動シーケンスに「env→BaseUrl 解決 → version.json 解決 → 静的プロパティ設定 → Init」を足すだけ
+- env → `BaseUrl` のマッピングは**アプリ config** が持つ（AssetVault はホストを知らない）
 - 強制アプデゲートは AssetVault に含めない（アプリ層）
 
 ---


### PR DESCRIPTION
## 概要
AssetVault に CDN 配信のランタイム層を追加する。アプリ版とアセット版を分離し、起動時に version.json を解決して Addressables の RemoteLoadPath を実行時に向ける。設計は docs/design-unilab-asset-cdn.md を参照。

## 主な内容
- AssetVaultRuntime: RemoteLoadPath の実行時トークン {…Environment}/{…ContentPath} が参照する静的状態
- ContentVersionInfo: version.json の中身（ContentVersion=文字列一致判定 / Path=URLセグメント）
- IContentVersionResolver: コンテンツ版解決の抽象（アプリ層/BFF 差し替え可）
- RemoteContentVersionResolver: 既定 HTTP 実装（UnityWebRequest＋タイムアウト15秒）。取得処理を注入可能にしてテスタブル化。OCE 素通し・失敗は AssetVaultException に変換
- 非推奨 API 修正: FindFirstObjectByType → FindAnyObjectByType
- EditMode テスト: ContentVersionInfo / AssetVaultRuntime / RemoteContentVersionResolver（URL正規化・マッピング・例外非二重ラップ・不正JSON・OCE素通し）。Unity Test Runner 通過済み

## 残作業（別途）
- Addressables Profile の RemoteLoadPath を実行時トークン入りに変更（Unity 手作業）
- 強制アプデゲート・デバッグ上書き decorator は後続

実装は Codex 生成 → Claude レビューのループで作成。

Generated with Claude Code