### PR TITLE
feat: AssetResource フォルダ規約による Addressables 自動構成メニューを追加

### DIFF
--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupMenu.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupMenu.cs
@@ -1,0 +1,317 @@
+using System.Collections.Generic;
+using System.IO;
+using UnityEditor;
+using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetResource のフォルダ規約から Addressables を自動構成するメニューコマンドを提供します。
+    /// </summary>
+    public static class AssetVaultSetupMenu
+    {
+        private const string BaseMenuPath = "UniLab/AssetVault/Setup/";
+        private const string SyncAssetResourceMenuPath = BaseMenuPath + "Sync AssetResource";
+        private const string OpenSetupSettingsMenuPath = BaseMenuPath + "Open Setup Settings";
+        private const string LocalBuildPathVariableName = "LocalBuildPath";
+        private const string LocalLoadPathVariableName = "LocalLoadPath";
+        private const string RemoteBuildPathVariableName = "RemoteBuildPath";
+        private const string RemoteLoadPathVariableName = "RemoteLoadPath";
+        private const string LocalBuildPathValue = "[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]";
+        private const string LocalLoadPathValue = "{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]";
+        private const string RemoteBuildPathValue = "ServerData/[BuildTarget]";
+        private const string BuildTargetToken = "[BuildTarget]";
+        private const string BaseUrlPropertyName = "BaseUrl";
+        private const string ContentPathPropertyName = "ContentPath";
+        private const string LocalGroupPrefix = "Local_";
+        private const string RemoteGroupPrefix = "Remote_";
+        private const string InternalFolderName = "Internal";
+        private const string ExternalFolderName = "External";
+        private const string DefaultLocalGroupName = LocalGroupPrefix + InternalFolderName;
+        private const string DefaultRemoteGroupName = RemoteGroupPrefix + ExternalFolderName;
+        private const string CategorySkippedMessageFormat = "AssetVault setup skipped because folder was not found: {0}";
+        private const string DuplicateAddressWarningLineFormat = "重複アドレス: {0}（{1} と {2}）";
+        private const string SyncCompletedMessage = "AssetVault Addressables setup completed.";
+
+        /// <summary>
+        /// AssetResource の Internal / External フォルダ規約を Addressables に同期します。
+        /// </summary>
+        [MenuItem(SyncAssetResourceMenuPath)]
+        public static void SyncAssetResource()
+        {
+            if (!AddressableSettingsAccessor.TryGetSettings(out var settings))
+            {
+                return;
+            }
+
+            EnsureProfileValue(settings, LocalBuildPathVariableName, LocalBuildPathValue);
+            EnsureProfileValue(settings, LocalLoadPathVariableName, LocalLoadPathValue);
+            EnsureProfileValue(settings, RemoteBuildPathVariableName, RemoteBuildPathValue);
+            EnsureProfileValue(settings, RemoteLoadPathVariableName, CreateRemoteLoadPath());
+
+            settings.profileSettings.SetValue(settings.activeProfileId, RemoteLoadPathVariableName, CreateRemoteLoadPath());
+            settings.profileSettings.SetValue(settings.activeProfileId, RemoteBuildPathVariableName, RemoteBuildPathValue);
+
+            var assetVaultSetupSettings = AssetVaultSetupSettings.GetOrCreate();
+            var rootPath = NormalizeAssetPath(assetVaultSetupSettings.RootPath);
+            var duplicateAddressCollector = new DuplicateAddressCollector();
+            SyncCategory(settings, rootPath + "/" + InternalFolderName, true, duplicateAddressCollector);
+            SyncCategory(settings, rootPath + "/" + ExternalFolderName, false, duplicateAddressCollector);
+
+            EditorUtility.SetDirty(settings);
+            AssetDatabase.SaveAssets();
+            duplicateAddressCollector.LogWarning();
+            Debug.Log(SyncCompletedMessage);
+        }
+
+        /// <summary>
+        /// AssetVaultSetupSettings を選択して Inspector で開きます。
+        /// </summary>
+        [MenuItem(OpenSetupSettingsMenuPath)]
+        public static void OpenSetupSettings()
+        {
+            Selection.activeObject = AssetVaultSetupSettings.GetOrCreate();
+        }
+
+        private static void SyncCategory(
+            AddressableAssetSettings settings,
+            string categoryRoot,
+            bool isLocal,
+            DuplicateAddressCollector duplicateAddressCollector)
+        {
+            if (!AssetDatabase.IsValidFolder(categoryRoot))
+            {
+                Debug.Log(string.Format(CategorySkippedMessageFormat, categoryRoot));
+                return;
+            }
+
+            var subFolders = AssetDatabase.GetSubFolders(categoryRoot);
+            foreach (var subFolder in subFolders)
+            {
+                var groupName = GetGroupName(subFolder, isLocal);
+                var group = EnsureGroup(settings, groupName, isLocal);
+                RegisterFolder(settings, group, subFolder, categoryRoot, duplicateAddressCollector);
+            }
+
+            RegisterDirectAssets(settings, categoryRoot, isLocal, duplicateAddressCollector);
+        }
+
+        private static AddressableAssetGroup EnsureGroup(AddressableAssetSettings settings, string groupName, bool isLocal)
+        {
+            var group = settings.FindGroup(groupName);
+            if (group == null)
+            {
+                group = settings.CreateGroup(
+                    groupName,
+                    false,
+                    false,
+                    false,
+                    null,
+                    typeof(BundledAssetGroupSchema),
+                    typeof(ContentUpdateGroupSchema));
+            }
+
+            ConfigureBundledAssetGroupSchema(settings, group, isLocal);
+            ConfigureContentUpdateGroupSchema(group, isLocal);
+            return group;
+        }
+
+        private static void RegisterFolder(
+            AddressableAssetSettings settings,
+            AddressableAssetGroup group,
+            string folder,
+            string categoryRoot,
+            DuplicateAddressCollector duplicateAddressCollector)
+        {
+            var guids = AssetDatabase.FindAssets(string.Empty, new[] { folder });
+            foreach (var guid in guids)
+            {
+                RegisterAsset(settings, group, guid, categoryRoot, duplicateAddressCollector);
+            }
+        }
+
+        private static void RegisterDirectAssets(
+            AddressableAssetSettings settings,
+            string categoryRoot,
+            bool isLocal,
+            DuplicateAddressCollector duplicateAddressCollector)
+        {
+            var group = default(AddressableAssetGroup);
+            var guids = AssetDatabase.FindAssets(string.Empty, new[] { categoryRoot });
+            foreach (var guid in guids)
+            {
+                var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                if (AssetDatabase.IsValidFolder(assetPath))
+                {
+                    continue;
+                }
+
+                var directoryPath = NormalizeAssetPath(Path.GetDirectoryName(assetPath));
+                if (directoryPath != categoryRoot)
+                {
+                    continue;
+                }
+
+                if (group == null)
+                {
+                    var defaultGroupName = isLocal ? DefaultLocalGroupName : DefaultRemoteGroupName;
+                    group = EnsureGroup(settings, defaultGroupName, isLocal);
+                }
+
+                RegisterAsset(settings, group, guid, categoryRoot, duplicateAddressCollector);
+            }
+        }
+
+        private static void RegisterAsset(
+            AddressableAssetSettings settings,
+            AddressableAssetGroup group,
+            string guid,
+            string categoryRoot,
+            DuplicateAddressCollector duplicateAddressCollector)
+        {
+            var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                return;
+            }
+
+            var entry = settings.CreateOrMoveEntry(guid, group);
+            if (entry == null)
+            {
+                return;
+            }
+
+            entry.address = CreateAddress(assetPath, categoryRoot);
+            duplicateAddressCollector.Record(entry.address, assetPath);
+        }
+
+        private static void ConfigureBundledAssetGroupSchema(AddressableAssetSettings settings, AddressableAssetGroup group, bool isLocal)
+        {
+            var bundledAssetGroupSchema = group.GetSchema<BundledAssetGroupSchema>();
+            if (bundledAssetGroupSchema == null)
+            {
+                bundledAssetGroupSchema = group.AddSchema<BundledAssetGroupSchema>();
+            }
+
+            var buildPathVariableName = isLocal ? LocalBuildPathVariableName : RemoteBuildPathVariableName;
+            var loadPathVariableName = isLocal ? LocalLoadPathVariableName : RemoteLoadPathVariableName;
+            bundledAssetGroupSchema.BuildPath.SetVariableByName(settings, buildPathVariableName);
+            bundledAssetGroupSchema.LoadPath.SetVariableByName(settings, loadPathVariableName);
+            bundledAssetGroupSchema.BundleNaming = BundledAssetGroupSchema.BundleNamingStyle.AppendHash;
+        }
+
+        private static void ConfigureContentUpdateGroupSchema(AddressableAssetGroup group, bool isLocal)
+        {
+            var contentUpdateGroupSchema = group.GetSchema<ContentUpdateGroupSchema>();
+            if (contentUpdateGroupSchema == null)
+            {
+                contentUpdateGroupSchema = group.AddSchema<ContentUpdateGroupSchema>();
+            }
+
+            contentUpdateGroupSchema.StaticContent = isLocal;
+        }
+
+        private static void EnsureProfileValue(AddressableAssetSettings settings, string variableName, string defaultValue)
+        {
+            var variableNames = settings.profileSettings.GetVariableNames();
+            if (variableNames.Contains(variableName))
+            {
+                return;
+            }
+
+            settings.profileSettings.CreateValue(variableName, defaultValue);
+        }
+
+        private static string CreateRemoteLoadPath()
+        {
+            var runtimeTypeName = typeof(UniLab.AssetVault.AssetVaultRuntime).FullName;
+            return $"{{{runtimeTypeName}.{BaseUrlPropertyName}}}/{{{runtimeTypeName}.{ContentPathPropertyName}}}/{BuildTargetToken}";
+        }
+
+        private static string CreateAddress(string assetPath, string categoryRoot)
+        {
+            var relativePath = assetPath.Substring(categoryRoot.Length + "/".Length);
+            var extension = Path.GetExtension(relativePath);
+            if (string.IsNullOrEmpty(extension))
+            {
+                return relativePath;
+            }
+
+            return relativePath.Substring(0, relativePath.Length - extension.Length);
+        }
+
+        private static string GetGroupName(string folderPath, bool isLocal)
+        {
+            var groupPrefix = isLocal ? LocalGroupPrefix : RemoteGroupPrefix;
+            return groupPrefix + Path.GetFileName(folderPath);
+        }
+
+        private static string NormalizeAssetPath(string assetPath)
+        {
+            if (assetPath == null || assetPath == "")
+            {
+                return "";
+            }
+
+            return assetPath.Replace("\\", "/").TrimEnd('/');
+        }
+
+        private sealed class DuplicateAddressCollector
+        {
+            private readonly Dictionary<string, string> _registeredAssetPathsByAddress = new Dictionary<string, string>();
+            private readonly List<DuplicateAddress> _duplicateAddresses = new List<DuplicateAddress>();
+
+            public void Record(string address, string assetPath)
+            {
+                if (!_registeredAssetPathsByAddress.TryGetValue(address, out var registeredAssetPath))
+                {
+                    _registeredAssetPathsByAddress.Add(address, assetPath);
+                    return;
+                }
+
+                if (registeredAssetPath == assetPath)
+                {
+                    return;
+                }
+
+                _duplicateAddresses.Add(new DuplicateAddress(address, registeredAssetPath, assetPath));
+            }
+
+            public void LogWarning()
+            {
+                if (_duplicateAddresses.Count <= 0)
+                {
+                    return;
+                }
+
+                var warningLines = new List<string>();
+                foreach (var duplicateAddress in _duplicateAddresses)
+                {
+                    warningLines.Add(string.Format(
+                        DuplicateAddressWarningLineFormat,
+                        duplicateAddress.Address,
+                        duplicateAddress.FirstAssetPath,
+                        duplicateAddress.DuplicateAssetPath));
+                }
+
+                Debug.LogWarning(string.Join("\n", warningLines));
+            }
+        }
+
+        private readonly struct DuplicateAddress
+        {
+            public DuplicateAddress(string address, string firstAssetPath, string duplicateAssetPath)
+            {
+                Address = address;
+                FirstAssetPath = firstAssetPath;
+                DuplicateAssetPath = duplicateAssetPath;
+            }
+
+            public string Address { get; }
+            public string FirstAssetPath { get; }
+            public string DuplicateAssetPath { get; }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupMenu.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupMenu.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1c3c398464a24403a9341b9a15f5e5fc

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
@@ -1,0 +1,68 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetVault の Addressables 自動構成に使う設定を保持します。
+    /// </summary>
+    public sealed class AssetVaultSetupSettings : ScriptableObject
+    {
+        /// <summary>
+        /// AssetResource の既定ルートパスです。
+        /// </summary>
+        public const string DefaultRootPath = "Assets/AssetResource";
+
+        /// <summary>
+        /// 設定アセットの保存先パスです。
+        /// </summary>
+        public const string AssetPath = "Assets/Generated/UniLab/AssetVaultSetupSettings.asset";
+
+        private const string GeneratedFolderPath = "Assets/Generated";
+        private const string UniLabGeneratedFolderPath = "Assets/Generated/UniLab";
+        private const string AssetsFolderPath = "Assets";
+        private const string GeneratedFolderName = "Generated";
+        private const string UniLabFolderName = "UniLab";
+
+        [SerializeField] private string _rootPath = DefaultRootPath;
+
+        /// <summary>
+        /// AssetResource のルートパスを取得します。
+        /// </summary>
+        public string RootPath => _rootPath;
+
+        /// <summary>
+        /// 設定アセットを取得し、存在しない場合は作成します。
+        /// </summary>
+        public static AssetVaultSetupSettings GetOrCreate()
+        {
+            var settings = AssetDatabase.LoadAssetAtPath<AssetVaultSetupSettings>(AssetPath);
+            if (settings != null)
+            {
+                return settings;
+            }
+
+            EnsureFolder();
+
+            settings = CreateInstance<AssetVaultSetupSettings>();
+            AssetDatabase.CreateAsset(settings, AssetPath);
+            AssetDatabase.SaveAssets();
+            return settings;
+        }
+
+        private static void EnsureFolder()
+        {
+            if (!AssetDatabase.IsValidFolder(GeneratedFolderPath))
+            {
+                AssetDatabase.CreateFolder(AssetsFolderPath, GeneratedFolderName);
+            }
+
+            if (AssetDatabase.IsValidFolder(UniLabGeneratedFolderPath))
+            {
+                return;
+            }
+
+            AssetDatabase.CreateFolder(GeneratedFolderPath, UniLabFolderName);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 26f0d2f42d3c644a8bd75041149e066c

--- a/docs/design-unilab-asset-cdn.md
+++ b/docs/design-unilab-asset-cdn.md
@@ -198,14 +198,39 @@ sequenceDiagram
 
 ---
 
-## アセットの配置（グループ・パッキング・ラベル）
+## アセットの配置（フォルダ規約・グループ・パッキング・ラベル）
 
-**グループ分割（配信ライフサイクルで分ける）**
+### フォルダ規約（分類の真実）
 
-| グループ | 変更可否 | 配置 | 例 |
-|---|---|---|---|
-| `Local_Boot` | Cannot Change Post Release | アプリ同梱（StreamingAssets） | 起動必須の最小限：ブートシーン・共通 UI |
-| `Remote_<feature>` | Can Change Post Release | CDN | `Remote_Characters` / `Remote_Stages` / `Remote_UI` / `Remote_Audio` |
+ソースは **`Assets/AssetResource/{Internal|External}/<Sub>/`** に置く。トップ階層が配信種別を、直下サブフォルダがグループ単位を決める。
+
+```
+Assets/AssetResource/        ← ルートは設定で変更可（既定 Assets/AssetResource）
+├── Internal/<Sub>/...   → Local（同梱）  グループ Local_<Sub>
+└── External/<Sub>/...   → Remote（CDN）  グループ Remote_<Sub>
+```
+
+| カテゴリ | フォルダ | グループ | 変更可否 | バンドル出力 |
+|---|---|---|---|---|
+| **Local（同梱）** | `Internal/<Sub>` | `Local_<Sub>` | Cannot Change（StaticContent=true） | アプリ同梱（StreamingAssets へ**自動・不可視**出力） |
+| **Remote（CDN）** | `External/<Sub>` | `Remote_<Sub>` | Can Change（StaticContent=false） | CDN（`ServerData/`→アップロード） |
+
+- **ソースのフォルダ位置は自由**（Addressables は GUID 参照）。`Internal/External` 直下のサブフォルダ構成は任意。直置きは既定グループ `Local_Internal` / `Remote_External`
+- **StreamingAssets はソースの置き場ではない**。Local バンドルのビルド成果物が自動的に入るだけで、開発者は意識しない
+- 両カテゴリとも `IAssetScope.LoadAssetAsync` で透過的にロード（アプリコードは Local/Remote を意識しない）。実行時トークン（BaseUrl/ContentPath）は **Remote だけ**に効く
+- アドレス（ランタイムキー）= **カテゴリルート相対パス・拡張子なし**（`External/Characters/hero.prefab` → `Characters/hero`）。Internal/External 間で同一相対パスがあると衝突するため、セットアップ時に重複アドレスを警告する
+
+### セットアップ自動化（エディタメニュー）
+
+`UniLab.AssetVault.Editor` に以下を用意。手作業の Profile/グループ設定を排除する。
+
+| メニュー | 役割 |
+|---|---|
+| `UniLab/AssetVault/Setup/Sync AssetResource` | フォルダ規約を Addressables に同期（冪等）。Profile 変数（`RemoteLoadPath`=実行時トークン定数 / `RemoteBuildPath`=`ServerData/[BuildTarget]`）設定、`Internal/External` 走査、サブフォルダ→グループ生成、アセットを `CreateOrMoveEntry` で登録、schema（Build/Load Path・AppendHash・StaticContent）設定、重複アドレス警告 |
+| `UniLab/AssetVault/Setup/Open Setup Settings` | `AssetVaultSetupSettings`（ルートパス変更用 ScriptableObject）を Inspector で開く |
+
+- RemoteLoadPath のトークンは `typeof(AssetVaultRuntime).FullName` から組み立て（リネーム耐性）
+- **env は実行時 BaseUrl で切替 → Addressables Profile は1つでよい**
 
 **バンドルのパッキング**
 
@@ -269,6 +294,7 @@ sequenceDiagram
 | `AssetVaultRuntime` | runtime（static） | `static string BaseUrl`（ホスト込み基底）/ `static string ContentPath`（版セグメント）。`InitializeAsync` 前にアプリ層がセット。RemoteLoadPath の実行時トークンが参照 |
 | `IContentVersionResolver` | runtime（抽象） | 解決済み `BaseUrl` 配下の `version.json` を取得して版を返す。実装はアプリ層 / BFF。デバッグ上書きの優先度もここで解決 |
 | `RemoteContentVersionResolver` | runtime（既定実装） | `{BaseUrl}/version.json` を `UnityWebRequest`（タイムアウト付き）で取得・パース。取得処理は注入可能でテスタブル |
+| `AssetVaultSetupSettings` / `AssetVaultSetupMenu` | editor | フォルダ規約から Addressables を自動構成（上記「セットアップ自動化」）。ルートパスは設定で変更可 |
 
 - 既存の `IAssetVaultService` / 状態機械 / 差分DL / `IAssetScope` は**不変**。起動シーケンスに「env→BaseUrl 解決 → version.json 解決 → 静的プロパティ設定 → Init」を足すだけ
 - env → `BaseUrl` のマッピングは**アプリ config** が持つ（AssetVault はホストを知らない）


### PR DESCRIPTION
## 概要
`Assets/AssetResource/{Internal|External}/<Sub>` のフォルダ規約から Addressables を自動構成するエディタメニューを追加。手作業の Profile/グループ設定を排除する。設計は docs/design-unilab-asset-cdn.md。

## 主な内容
- `AssetVaultSetupMenu`:
  - `UniLab/AssetVault/Setup/Sync AssetResource`（冪等）: Profile 変数（RemoteLoadPath=実行時トークン定数 / RemoteBuildPath）設定、Internal→Local_*/External→Remote_* グループ生成、アセットを CreateOrMoveEntry で登録、schema（Build/Load Path・AppendHash・StaticContent）設定、重複アドレス警告
  - `UniLab/AssetVault/Setup/Open Setup Settings`: ルートパス変更用 ScriptableObject を開く
- `AssetVaultSetupSettings`: ルートパス（既定 Assets/AssetResource、変更可）
- アドレス = カテゴリルート相対パス（拡張子なし）。env は実行時 BaseUrl で切替 → Addressables Profile は1つでよい
- 設計書に「フォルダ規約・Local/Remote 2カテゴリ・セットアップ自動化」を追記

## 確認
- Unity 6000.4 でコンパイル確認・Sync 動作確認済み

実装は Codex → Claude レビューのループ（アドレス衝突検知・定数整理を反映）。

Generated with Claude Code