### PR TITLE
AssetVault 改善: Debug適用責務分離・堅牢化・入力検証・テスト容易化

### DIFF
--- a/Assets/UniLab/AssetVault/Debug/AssetVaultDebugBootstrap.cs
+++ b/Assets/UniLab/AssetVault/Debug/AssetVaultDebugBootstrap.cs
@@ -12,24 +12,27 @@ namespace UniLab.AssetVault.Debugging
         private const string PresetMissingMessageFormat = "AssetVault Debug Override is enabled but preset '{0}' was not found. Overrides were skipped.";
         private const string PresetEmptyMessage = "AssetVault Debug Override is enabled but no presets are registered. Overrides were skipped.";
 
+        // 直近のこのブートストラップが BaseUrl を上書きしたか。アプリが設定した値を消さないよう、
+        // 「自分が入れた値」だけをクリア対象にするためのフラグ（ドメインリロード無効時も含めセッション跨ぎで一貫させる）。
+        private static bool _applied;
+
         // アプリ初期化（IAssetVaultService.InitializeAsync）より前に値を入れる狙いで BeforeSceneLoad を使う。
         // ただしアプリ初期化との厳密な前後は保証されないため、アプリ側が config から設定する場合はそちらが優先される（順序はアプリ責務）。
         // 上書きするのは BaseUrl のみ。ContentPath（版）は version.json 解決に任せるため一切触らない。
-        // ドメインリロード無効時は static の AssetVaultRuntime.BaseUrl に前回値が残るため、無効・未解決時は null クリアしてリークを防ぐ。
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
         private static void Apply()
         {
             var settings = AssetVaultDebugEnvironmentSettings.Load();
             if (settings == null || !settings.OverrideEnabled)
             {
-                AssetVaultRuntime.BaseUrl = null;
+                ClearIfApplied();
                 return;
             }
 
             var preset = settings.ResolveSelectedPreset();
             if (preset == null)
             {
-                AssetVaultRuntime.BaseUrl = null;
+                ClearIfApplied();
                 var selectedName = settings.SelectedPresetName;
                 Debug.LogWarning(string.IsNullOrEmpty(selectedName)
                     ? PresetEmptyMessage
@@ -38,6 +41,20 @@ namespace UniLab.AssetVault.Debugging
             }
 
             AssetVaultRuntime.BaseUrl = preset.BaseUrl;
+            _applied = true;
+        }
+
+        // 自分が上書きした場合のみ null へ戻す。ドメインリロード有効時は _applied が初期化されるため、
+        // アプリが設定した BaseUrl を消すことはない。無効時のみ前回の上書き残留をクリアする。
+        private static void ClearIfApplied()
+        {
+            if (!_applied)
+            {
+                return;
+            }
+
+            AssetVaultRuntime.BaseUrl = null;
+            _applied = false;
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Debug/AssetVaultDebugEnvironmentSettings.cs
+++ b/Assets/UniLab/AssetVault/Debug/AssetVaultDebugEnvironmentSettings.cs
@@ -36,10 +36,16 @@ namespace UniLab.AssetVault.Debugging
 
         /// <summary>
         /// 指定したプリセットを選択して上書きを有効化します。UI からは選べず、QA/開発のコード経由で呼びます。
-        /// 存在しない名前を渡した場合も値は保持し、適用時に解決失敗として警告されます。
+        /// 空名・未登録名は設定時点で弾く（適用時まで失敗を遅延させない）。
         /// </summary>
         public void Activate(string presetName)
         {
+            if (string.IsNullOrEmpty(presetName) || _presets.All(preset => preset.DisplayName != presetName))
+            {
+                Debug.LogError($"AssetVault Debug Override: preset '{presetName}' is empty or not registered. Activation skipped.");
+                return;
+            }
+
             _selectedPresetName = presetName;
             _overrideEnabled = true;
             MarkDirty();
@@ -53,18 +59,13 @@ namespace UniLab.AssetVault.Debugging
         }
 
         /// <summary>
-        /// 現在選択中のプリセットを解決します。未登録・名称不一致は null、未選択時は先頭プリセットを返します。
+        /// 現在選択中のプリセットを解決します。未登録・未選択・名称不一致はいずれも null を返します（先頭への暗黙フォールバックはしない）。
         /// </summary>
         public AssetVaultDebugEnvironmentPreset ResolveSelectedPreset()
         {
-            if (_presets.Count <= 0)
+            if (_presets.Count <= 0 || string.IsNullOrEmpty(_selectedPresetName))
             {
                 return null;
-            }
-
-            if (string.IsNullOrEmpty(_selectedPresetName))
-            {
-                return _presets[0];
             }
 
             return _presets.FirstOrDefault(preset => preset.DisplayName == _selectedPresetName);
@@ -118,6 +119,12 @@ namespace UniLab.AssetVault.Debugging
 
         private void MarkDirty()
         {
+            // Play 中の変更は永続化しない（停止時に破棄）。QA の一時操作がアセット／dev ビルドへ焼き込まれるのを防ぐ。
+            if (EditorApplication.isPlaying)
+            {
+                return;
+            }
+
             EditorUtility.SetDirty(this);
             AssetDatabase.SaveAssets();
         }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
@@ -23,12 +23,13 @@ namespace UniLab.AssetVault.Editor
         {
             var relativePath = assetPath.Substring(categoryRoot.Length + "/".Length);
             var extension = Path.GetExtension(relativePath);
-            if (string.IsNullOrEmpty(extension))
+            if (!string.IsNullOrEmpty(extension))
             {
-                return relativePath;
+                relativePath = relativePath.Substring(0, relativePath.Length - extension.Length);
             }
 
-            return relativePath.Substring(0, relativePath.Length - extension.Length);
+            // アドレスは大文字小文字を保持する（アプリ側ロードキーと一致させる）。区切りのみ "/" に統一し前後空白を除去する。
+            return relativePath.Replace("\\", "/").Trim();
         }
 
         /// <summary>

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultDebugEnvironmentSettingsEditor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultDebugEnvironmentSettingsEditor.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using UniLab.AssetVault.Debugging;
 using UnityEditor;
 
@@ -31,6 +33,8 @@ namespace UniLab.AssetVault.Editor
             EditorGUILayout.PropertyField(_presetsProperty, true);
             serializedObject.ApplyModifiedProperties();
 
+            DrawValidationWarnings((AssetVaultDebugEnvironmentSettings)target);
+
             EditorGUILayout.Space();
 
             // 現在の選択・有効状態はコードでのみ変更できるため、読み取り専用で状態を示す。
@@ -40,6 +44,36 @@ namespace UniLab.AssetVault.Editor
                 EditorGUILayout.Toggle("Override Enabled", settings.OverrideEnabled);
                 EditorGUILayout.TextField("Selected Preset", settings.SelectedPresetName);
             }
+        }
+
+        // プリセットの空名・重複名・空 URL を警告する（実行時の解決失敗・誤環境ロードを未然に防ぐ）。
+        private static void DrawValidationWarnings(AssetVaultDebugEnvironmentSettings settings)
+        {
+            var issues = new List<string>();
+            var seenNames = new HashSet<string>();
+            foreach (var preset in settings.Presets)
+            {
+                if (string.IsNullOrEmpty(preset.DisplayName))
+                {
+                    issues.Add("表示名が空のプリセットがあります。");
+                }
+                else if (!seenNames.Add(preset.DisplayName))
+                {
+                    issues.Add($"表示名が重複しています: {preset.DisplayName}");
+                }
+
+                if (string.IsNullOrEmpty(preset.BaseUrl))
+                {
+                    issues.Add($"BaseUrl が空です: {(string.IsNullOrEmpty(preset.DisplayName) ? "(無名)" : preset.DisplayName)}");
+                }
+            }
+
+            if (issues.Count <= 0)
+            {
+                return;
+            }
+
+            EditorGUILayout.HelpBox(string.Join("\n", issues.Distinct()), MessageType.Warning);
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -27,6 +27,7 @@ namespace UniLab.AssetVault.Editor
         private const string ContentPathPropertyName = "ContentPath";
         private const string CategorySkippedMessageFormat = "AssetVault setup skipped because folder was not found: {0}";
         private const string LocalFolderMissingMessage = "AssetVault setup aborted: the Local folder is required but not set. Assign it in AssetVaultSetupSettings.";
+        private const string ProfileVariableMissingMessageFormat = "Addressables profile variable '{0}' was not found; group build/load path may be misconfigured.";
         private const string DuplicateAddressFailureMessage = "AssetVault setup failed due to duplicate addresses. Resolve the following collisions and run sync again:\n{0}";
         private const string SyncCompletedMessage = "AssetVault Addressables setup completed.";
         private const string ContentStateMissingMessage = "Addressables content state file was not found. Run a new build before a content update build.";
@@ -48,7 +49,17 @@ namespace UniLab.AssetVault.Editor
                 return false;
             }
 
-            AddressableAssetSettings.BuildPlayerContent(out AddressablesPlayerBuildResult result);
+            AddressablesPlayerBuildResult result;
+            try
+            {
+                AddressableAssetSettings.BuildPlayerContent(out result);
+            }
+            catch (System.Exception exception)
+            {
+                Debug.LogError($"{NewBuildFailedMessage} {exception.Message}");
+                return false;
+            }
+
             if (result == null)
             {
                 Debug.LogError(NewBuildFailedMessage);
@@ -83,7 +94,17 @@ namespace UniLab.AssetVault.Editor
                 return false;
             }
 
-            var result = ContentUpdateScript.BuildContentUpdate(settings, contentStatePath);
+            AddressablesPlayerBuildResult result;
+            try
+            {
+                result = ContentUpdateScript.BuildContentUpdate(settings, contentStatePath);
+            }
+            catch (System.Exception exception)
+            {
+                Debug.LogError($"{ContentUpdateFailedMessage} {exception.Message}");
+                return false;
+            }
+
             if (result == null)
             {
                 Debug.LogError(ContentUpdateFailedMessage);
@@ -98,6 +119,14 @@ namespace UniLab.AssetVault.Editor
 
             Debug.Log(ContentUpdateCompletedMessage);
             return true;
+        }
+
+        /// <summary>
+        /// Content Update ビルドが可能か（前回の content state file が存在するか）を返します。UI のボタン制御に使います。
+        /// </summary>
+        public static bool CanBuildContentUpdate()
+        {
+            return File.Exists(ContentUpdateScript.GetContentStateDataPath(false));
         }
 
         // --- Setup ---
@@ -135,16 +164,26 @@ namespace UniLab.AssetVault.Editor
 
             var duplicateAddressCollector = new AssetVaultDuplicateAddressCollector();
             var registeredGuids = new HashSet<string>();
-            SyncCategory(settings, localFolderPath, true, duplicateAddressCollector, registeredGuids);
 
-            // Remote は任意。設定されている場合のみ同期する。
-            var remoteFolderPath = assetVaultSetupSettings.RemoteFolderPath;
-            if (remoteFolderPath != null)
+            // 大量アセットでのインポート再評価を抑えるためバッチ化する。
+            AssetDatabase.StartAssetEditing();
+            try
             {
-                SyncCategory(settings, remoteFolderPath, false, duplicateAddressCollector, registeredGuids);
-            }
+                SyncCategory(settings, localFolderPath, true, duplicateAddressCollector, registeredGuids);
 
-            PruneStaleEntries(settings, registeredGuids);
+                // Remote は任意。設定されている場合のみ同期する。
+                var remoteFolderPath = assetVaultSetupSettings.RemoteFolderPath;
+                if (remoteFolderPath != null)
+                {
+                    SyncCategory(settings, remoteFolderPath, false, duplicateAddressCollector, registeredGuids);
+                }
+
+                PruneStaleEntries(settings, registeredGuids);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
 
             EditorUtility.SetDirty(settings);
             AssetDatabase.SaveAssets();
@@ -175,9 +214,13 @@ namespace UniLab.AssetVault.Editor
         /// </summary>
         public static AssetVaultStatus GetStatus()
         {
-            var setupSettings = AssetVaultSetupSettings.GetOrCreate();
-            var localFolderPath = setupSettings.LocalFolderPath ?? string.Empty;
-            var remoteFolderPath = setupSettings.RemoteFolderPath ?? string.Empty;
+            var localFolderPath = string.Empty;
+            var remoteFolderPath = string.Empty;
+            if (AssetVaultSetupSettings.TryLoad(out var setupSettings))
+            {
+                localFolderPath = setupSettings.LocalFolderPath ?? string.Empty;
+                remoteFolderPath = setupSettings.RemoteFolderPath ?? string.Empty;
+            }
 
             if (!AddressableSettingsAccessor.TryGetSettingsSilently(out var settings))
             {
@@ -226,6 +269,7 @@ namespace UniLab.AssetVault.Editor
         private static AddressableAssetGroup EnsureGroup(AddressableAssetSettings settings, string groupName, bool isLocal)
         {
             var group = settings.FindGroup(groupName);
+            var created = false;
             if (group == null)
             {
                 group = settings.CreateGroup(
@@ -236,9 +280,10 @@ namespace UniLab.AssetVault.Editor
                     null,
                     typeof(BundledAssetGroupSchema),
                     typeof(ContentUpdateGroupSchema));
+                created = true;
             }
 
-            ConfigureBundledAssetGroupSchema(settings, group, isLocal);
+            ConfigureBundledAssetGroupSchema(settings, group, isLocal, created);
             ConfigureContentUpdateGroupSchema(group, isLocal);
             return group;
         }
@@ -340,19 +385,33 @@ namespace UniLab.AssetVault.Editor
             }
         }
 
-        private static void ConfigureBundledAssetGroupSchema(AddressableAssetSettings settings, AddressableAssetGroup group, bool isLocal)
+        private static void ConfigureBundledAssetGroupSchema(AddressableAssetSettings settings, AddressableAssetGroup group, bool isLocal, bool created)
         {
             var bundledAssetGroupSchema = group.GetSchema<BundledAssetGroupSchema>();
             if (bundledAssetGroupSchema == null)
             {
                 bundledAssetGroupSchema = group.AddSchema<BundledAssetGroupSchema>();
+                created = true;
             }
 
+            // Build/Load パスは Local/Remote の振り分けに直結するため毎回強制する。
             var buildPathVariableName = isLocal ? LocalBuildPathVariableName : RemoteBuildPathVariableName;
             var loadPathVariableName = isLocal ? LocalLoadPathVariableName : RemoteLoadPathVariableName;
-            bundledAssetGroupSchema.BuildPath.SetVariableByName(settings, buildPathVariableName);
-            bundledAssetGroupSchema.LoadPath.SetVariableByName(settings, loadPathVariableName);
-            bundledAssetGroupSchema.BundleNaming = BundledAssetGroupSchema.BundleNamingStyle.AppendHash;
+            if (!bundledAssetGroupSchema.BuildPath.SetVariableByName(settings, buildPathVariableName))
+            {
+                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, buildPathVariableName));
+            }
+
+            if (!bundledAssetGroupSchema.LoadPath.SetVariableByName(settings, loadPathVariableName))
+            {
+                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, loadPathVariableName));
+            }
+
+            // BundleNaming は新規グループのみ既定値を設定し、既存グループの手動調整は尊重する。
+            if (created)
+            {
+                bundledAssetGroupSchema.BundleNaming = BundledAssetGroupSchema.BundleNamingStyle.AppendHash;
+            }
         }
 
         private static void ConfigureContentUpdateGroupSchema(AddressableAssetGroup group, bool isLocal)

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
@@ -31,6 +31,15 @@ namespace UniLab.AssetVault.Editor
         public string RemoteFolderPath => ResolveFolderPath(_remoteFolder);
 
         /// <summary>
+        /// 設定アセットを副作用なく読み込みます（存在しなければ false）。読み取り専用 UI から使い、アセットの自動生成を避けます。
+        /// </summary>
+        public static bool TryLoad(out AssetVaultSetupSettings settings)
+        {
+            settings = AssetDatabase.LoadAssetAtPath<AssetVaultSetupSettings>(AssetPath);
+            return settings != null;
+        }
+
+        /// <summary>
         /// 設定アセットを取得し、存在しない場合は作成します。フォルダはユーザーが Inspector で指定します。
         /// </summary>
         public static AssetVaultSetupSettings GetOrCreate()

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEditor;
 using UnityEngine;
 
@@ -5,11 +6,13 @@ namespace UniLab.AssetVault.Editor
 {
     /// <summary>
     /// <see cref="AssetVaultSetupSettings"/> の Inspector です。Local/Remote フォルダの意味を HelpBox で明示し、
-    /// 必須の Local フォルダが未設定の場合は警告します。フォルダ指定と Sync をこの1画面で完結させます。
+    /// 未設定・フォルダ以外・Local/Remote の重複を警告します。フォルダ指定と Sync をこの1画面で完結させます。
     /// </summary>
     [CustomEditor(typeof(AssetVaultSetupSettings))]
     public sealed class AssetVaultSetupSettingsEditor : UnityEditor.Editor
     {
+        private const string LocalFolderPropertyName = "_localFolder";
+        private const string RemoteFolderPropertyName = "_remoteFolder";
         private const string HelpMessage =
             "Sync AssetResource が走査するルートフォルダを指定します。\n"
             + "・Local Folder【必須】: プレイヤー同梱。直下サブフォルダ → グループ Local_<名>\n"
@@ -17,6 +20,9 @@ namespace UniLab.AssetVault.Editor
             + "フォルダ名は分類に影響しません（スロット自体が Local/Remote を決めます）。フォルダを指定して下のボタンで同期します。";
 
         private const string LocalMissingMessage = "Local Folder が未設定です。Local は必須のため、フォルダを指定するまで Sync できません。";
+        private const string LocalNotFolderMessage = "Local Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
+        private const string RemoteNotFolderMessage = "Remote Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
+        private const string OverlapMessage = "Local と Remote は別フォルダにしてください（同一・入れ子は二重登録やアドレス衝突を招きます）。";
 
         public override void OnInspectorGUI()
         {
@@ -26,20 +32,58 @@ namespace UniLab.AssetVault.Editor
             DrawDefaultInspector();
 
             var settings = (AssetVaultSetupSettings)target;
-            var localMissing = string.IsNullOrEmpty(settings.LocalFolderPath);
+            var localPath = settings.LocalFolderPath;
+            var remotePath = settings.RemoteFolderPath;
+            var localMissing = string.IsNullOrEmpty(localPath);
+            var hasOverlap = IsSameOrNested(localPath, remotePath);
+
             if (localMissing)
             {
                 EditorGUILayout.HelpBox(LocalMissingMessage, MessageType.Warning);
             }
 
+            // フィールドは割り当て済みだがフォルダとして解決できない（＝ファイル等）場合を明示する。
+            if (IsAssignedButNotFolder(LocalFolderPropertyName, localPath))
+            {
+                EditorGUILayout.HelpBox(LocalNotFolderMessage, MessageType.Warning);
+            }
+
+            if (IsAssignedButNotFolder(RemoteFolderPropertyName, remotePath))
+            {
+                EditorGUILayout.HelpBox(RemoteNotFolderMessage, MessageType.Warning);
+            }
+
+            if (hasOverlap)
+            {
+                EditorGUILayout.HelpBox(OverlapMessage, MessageType.Warning);
+            }
+
             EditorGUILayout.Space();
-            using (new EditorGUI.DisabledScope(localMissing))
+            using (new EditorGUI.DisabledScope(localMissing || hasOverlap))
             {
                 if (GUILayout.Button("Sync AssetResource"))
                 {
                     AssetVaultEditorOperations.SyncAssetResource();
                 }
             }
+        }
+
+        private bool IsAssignedButNotFolder(string propertyName, string resolvedPath)
+        {
+            var property = serializedObject.FindProperty(propertyName);
+            return property != null && property.objectReferenceValue != null && string.IsNullOrEmpty(resolvedPath);
+        }
+
+        private static bool IsSameOrNested(string a, string b)
+        {
+            if (string.IsNullOrEmpty(a) || string.IsNullOrEmpty(b))
+            {
+                return false;
+            }
+
+            return a == b
+                || a.StartsWith(b + "/", StringComparison.Ordinal)
+                || b.StartsWith(a + "/", StringComparison.Ordinal);
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
@@ -72,12 +72,21 @@ namespace UniLab.AssetVault.Editor
                 RefreshStatus();
             }
 
-            if (DrawActionButton(
-                "Content Update (Diff)",
-                "前回の content state からの差分だけをビルドします。配信済みアプリ向けにアセットを追加・更新するときに使います（先に New Build が必要）。"))
+            var canBuildContentUpdate = AssetVaultEditorOperations.CanBuildContentUpdate();
+            using (new EditorGUI.DisabledScope(!canBuildContentUpdate))
             {
-                AssetVaultEditorOperations.BuildContentUpdate();
-                RefreshStatus();
+                if (DrawActionButton(
+                    "Content Update (Diff)",
+                    "前回の content state からの差分だけをビルドします。配信済みアプリ向けにアセットを追加・更新するときに使います（先に New Build が必要）。"))
+                {
+                    AssetVaultEditorOperations.BuildContentUpdate();
+                    RefreshStatus();
+                }
+            }
+
+            if (!canBuildContentUpdate)
+            {
+                EditorGUILayout.HelpBox("content state file が見つかりません。先に New Build を実行してください。", MessageType.None);
             }
         }
 

--- a/docs/task-asset-vault-improvements.md
+++ b/docs/task-asset-vault-improvements.md
@@ -1,0 +1,55 @@
+# タスク: AssetVault 改善バックログ
+
+作成日: 2026-06-14
+対象: `Assets/UniLab/AssetVault/`（Editor / Debug 中心）
+出所: Codex レビュー（codex-cli 0.139.0）＋ Claude Code 分析
+関連: [asset-vault-guide.md](asset-vault-guide.md) / [design-unilab-asset-cdn.md](design-unilab-asset-cdn.md) / [review-asset-vault-editor-reorg.md](review-asset-vault-editor-reorg.md)
+
+> リオーガナイズ PR #8 を develop へマージ済み（マージコミット `679d62a`）。本書はその後の残改善タスク一覧。
+
+## 完了済み（PR #8 まで）
+- ダッシュボード化（`UniLab > AssetVault > Dashboard`）＋操作レイヤ分離（`AssetVaultEditorOperations`）
+- 同期を Local/Remote 2スロット方式へ（`AssetVaultSetupSettings`、Local 必須・Remote 任意、Sync は設定 Inspector に集約）
+- item1 古い `.asset` 再生成 / item2 Debug 選択メニュー / item4 stale エントリ・空グループ掃除 / item5 重複アドレス失敗化 / item9（純粋ロジック抽出＋EditMode テスト）
+- Debug Override の dev ビルド対応（`UniLab.AssetVault.Debug`、release ストリップ、BaseUrl のみ上書き、選択はコード/メニュー経由）
+- Sample 削除、旧 `AssetVaultProfileSwitcher` 廃止、ドキュメント更新
+
+---
+
+## 🔴 高（堅牢性・データ事故）
+1. Debug Override 適用責務の分離 — 無効時 `AssetVaultRuntime.BaseUrl = null` がアプリ設定値を消し得る。「上書きする時だけ触る」設計に。
+2. Play 中の `Activate`/`Deactivate` 即 `SaveAssets` — QA の一時切替が永続化。Play 中は揮発ストアへ退避。
+3. ビルド/プロファイル API の例外・戻り値ハンドリング — `BuildPlayerContent`/`ContentUpdate`/`SetVariableByName`/`CopyAsset`/`CreateFolder`/`DeleteAsset` の失敗を捕捉・通知。
+4. `Activate` の入力検証 — 存在しない/空/重複名を設定時に弾く（今は起動時まで失敗が遅延）。
+
+## 🟠 中（正しさ・運用）
+5. 既存 `Local_`/`Remote_` グループの無条件再設定 — 手動調整した schema を上書きし得る。
+6. 大量アセットで `StartAssetEditing`/進捗/キャンセルが無い — Editor が固まる。
+7. `ResolveSelectedPreset` の未選択→先頭フォールバック — Override 有効時に意図しない環境を向くリスク。「未選択は適用しない」へ。
+8. 入力検証（Inspector）— プリセット空名/重複名/空URL/URL形式、Local/Remote 同一・入れ子、`DefaultAsset` にファイル混入。
+9. address 正規化方針 — 大小文字/空白/日本語/同名別拡張子の扱い。
+10. Dashboard を開くだけで `GetOrCreate` が asset 生成 — 読み取り UI の副作用。`TryLoad` と分離。
+11. Build ボタンの事前条件未反映 — content state 不在でも押せる。`DisabledScope`＋理由表示。
+12. エラー通知の不統一 — `Debug.LogError`+bool と `AssetVaultException` の混在を整理。
+
+## 🟢 低（保守性・軽微）
+13. Sync に Undo 記録なし。
+14. グループ名がフォルダ末尾名のみ（衝突・意味不明名の余地）。
+15. `Presets` が内部 `List` 実体を `IReadOnlyList` で返す（`AsReadOnly`）。
+16. `AddressableSettingsAccessor` static 直参照（テスト差し替え不可）。
+17. item9 続き: `AddressableAssetSettings` 注入で `SyncAssetResource` の統合テスト。
+18. BuildProcessor: 一時 `Resources` フォルダ自体が残る／`callbackOrder` 固定。
+19. `Debug.asmdef` の `autoReferenced=true`（明示参照化で境界明確化）。
+20. `UNILAB_ADDRESSABLES` define があるがコードが `#if` で守られていない。
+21. Window Status が外部変更で自動更新されない。
+22. ログ文言の英日混在。
+
+## ⏸ 意図的に見送り（対応不要）
+- Remote プロファイル毎回上書きの非対称（Why コメント済み）
+- ボタン説明文の常時表示（要望どおり）
+- Status のグループ数を prefix で数える（所有マーカーとして許容）
+
+---
+
+## おすすめ着手順
+事故りやすさ順で **1 → 2 → 3 → 7 → 10**。次いで 8・11（UX の安全弁）、16・17（テスト基盤）。


### PR DESCRIPTION
## 概要
`docs/task-asset-vault-improvements.md` の 🔴高 / 🟠中 項目を実装。

## 高
- Debug Override 適用責務の分離（自分が上書きした時のみ null クリア。アプリ設定値を消さない）
- Play 中の `Activate`/`Deactivate` を永続化しない（停止で破棄）
- ビルド API（New Build / Content Update）の例外ハンドリング、profile 変数欠落の警告
- `Activate` の入力検証（空名・未登録名を設定時に弾く）

## 中
- 既存グループの BundleNaming を保持（新規時のみ既定設定）
- Sync を `StartAssetEditing`/`StopAssetEditing` でバッチ化
- `ResolveSelectedPreset` の未選択→先頭フォールバックを撤廃（null 返し）
- Inspector の入力検証（Local/Remote の同一・入れ子・フォルダ以外、プリセット空名・重複名・空URL）
- アドレス正規化（区切り統一・トリム）
- `GetStatus` を `TryLoad` 化（Dashboard を開くだけで asset を生成しない）
- Content Update ボタンを content state 不在時は無効化

## 確認
- Unity でコンパイル通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)