### PR TITLE
AssetVault: Component 拡張ロード（Scope レス）と InitializeAsync(baseUrl) 化

### DIFF
--- a/Assets/UniLab/AssetVault/AddressablesAssetVaultService.cs
+++ b/Assets/UniLab/AssetVault/AddressablesAssetVaultService.cs
@@ -16,6 +16,16 @@ namespace UniLab.AssetVault
     {
         private readonly ReactiveProperty<AssetVaultState> _state = new(AssetVaultState.NotInitialized);
         private readonly Subject<DownloadProgress> _downloadProgress = new();
+        private readonly Func<string, IContentVersionResolver> _contentVersionResolverFactory;
+
+        /// <summary>
+        /// 既定では version.json を HTTP 取得する <see cref="RemoteContentVersionResolver"/> を使います。
+        /// BFF 解決やテストでは <paramref name="contentVersionResolverFactory"/> を差し替えます。
+        /// </summary>
+        public AddressablesAssetVaultService(Func<string, IContentVersionResolver> contentVersionResolverFactory = null)
+        {
+            _contentVersionResolverFactory = contentVersionResolverFactory ?? (baseUrl => new RemoteContentVersionResolver(baseUrl));
+        }
 
         /// <summary>
         /// 起動処理とロード UI が状態遷移を監視する現在の配信状態を取得します。
@@ -28,14 +38,26 @@ namespace UniLab.AssetVault
         public Observable<DownloadProgress> OnDownloadProgress => _downloadProgress;
 
         /// <summary>
-        /// Addressables を初期化し、成功時にサービスを準備完了状態へ移行します。
+        /// BaseUrl を確定し、版を version.json から解決してから Addressables を初期化します。成功時に準備完了へ移行します。
         /// </summary>
-        public async UniTask InitializeAsync(CancellationToken cancellationToken)
+        public async UniTask InitializeAsync(string baseUrl, CancellationToken cancellationToken)
         {
             _state.Value = AssetVaultState.Initializing;
 
             try
             {
+                // Debug Override が BeforeSceneLoad で BaseUrl を入れていればそれを優先（QA）。無ければ引数を採用する。
+                // RemoteLoadPath トークンは AssetVaultRuntime を型名参照するため、初期化“前”に確定させる必要がある。
+                var effectiveBaseUrl = string.IsNullOrEmpty(AssetVaultRuntime.BaseUrl) ? baseUrl : AssetVaultRuntime.BaseUrl;
+                AssetVaultRuntime.BaseUrl = effectiveBaseUrl;
+
+                // 版（ContentPath）は version.json 解決に任せる。Local 専用（baseUrl 空）の場合は解決をスキップする。
+                if (!string.IsNullOrEmpty(effectiveBaseUrl))
+                {
+                    var contentVersion = await _contentVersionResolverFactory(effectiveBaseUrl).ResolveAsync(cancellationToken);
+                    AssetVaultRuntime.ContentPath = contentVersion.Path;
+                }
+
                 await Addressables.InitializeAsync().ToUniTask(cancellationToken: cancellationToken);
                 _state.Value = AssetVaultState.Ready;
             }

--- a/Assets/UniLab/AssetVault/AssetScopeHolder.cs
+++ b/Assets/UniLab/AssetVault/AssetScopeHolder.cs
@@ -1,0 +1,40 @@
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// GameObject に 1 つだけ付く、その GameObject 寿命に紐づく <see cref="IAssetScope"/> の隠しホルダーです。
+    /// <see cref="AssetVaultComponentExtensions"/> が裏で付与し、GameObject 破棄時にスコープを Dispose（＝ロード済み asset を一括 Release）します。
+    /// アプリコードが直接触る必要はありません。
+    /// </summary>
+    [DisallowMultipleComponent]
+    [AddComponentMenu("")]
+    internal sealed class AssetScopeHolder : MonoBehaviour
+    {
+        private IAssetScope _scope;
+
+        /// <summary>この GameObject に紐づくスコープ。初回アクセスで生成します。</summary>
+        public IAssetScope Scope => _scope ??= new AssetScope();
+
+        /// <summary>
+        /// GameObject に付いているホルダーを取得し、無ければ付与します（hideFlags で Inspector からは隠します）。
+        /// </summary>
+        public static AssetScopeHolder GetOrAttach(GameObject gameObject)
+        {
+            if (!gameObject.TryGetComponent(out AssetScopeHolder holder))
+            {
+                holder = gameObject.AddComponent<AssetScopeHolder>();
+                holder.hideFlags = HideFlags.HideInInspector;
+            }
+
+            return holder;
+        }
+
+        private void OnDestroy()
+        {
+            // GameObject 破棄＝この寿命でロードした全 asset を解放する。
+            _scope?.Dispose();
+            _scope = null;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultComponentExtensions.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultComponentExtensions.cs
@@ -1,0 +1,39 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// Component から Scope を意識せずにアセットをロード／生成するための拡張です。
+    /// ロードは呼び出し元 Component の GameObject 寿命に自動で紐づき、その GameObject 破棄時に Addressables から解放されます。
+    /// 画面/シーン単位でまとめたい、または共有アセットなど上位の寿命管理が要る場合は、明示的な <see cref="IAssetVaultService.CreateScope"/> を使ってください。
+    /// </summary>
+    public static class AssetVaultComponentExtensions
+    {
+        /// <summary>
+        /// key で asset をロードします。ハンドルは GameObject に紐づき、破棄時に自動 Release されます。
+        /// cancellationToken 未指定時は GameObject の破棄トークンを使い、ロード中のキャンセルも自動化します。
+        /// </summary>
+        public static UniTask<T> LoadAssetAsync<T>(this Component component, string key, CancellationToken cancellationToken = default)
+        {
+            var holder = AssetScopeHolder.GetOrAttach(component.gameObject);
+            return holder.Scope.LoadAssetAsync<T>(key, ResolveToken(holder, cancellationToken));
+        }
+
+        /// <summary>
+        /// key で GameObject を生成します。生成物のハンドルは呼び出し元 GameObject に紐づき、破棄時に自動 Release（生成物も破棄）されます。
+        /// </summary>
+        public static UniTask<GameObject> InstantiateAsync(this Component component, string key, Transform parent, CancellationToken cancellationToken = default)
+        {
+            var holder = AssetScopeHolder.GetOrAttach(component.gameObject);
+            return holder.Scope.InstantiateAsync(key, parent, ResolveToken(holder, cancellationToken));
+        }
+
+        // 未指定なら GameObject 破棄トークン（ホルダーも同じ GameObject の MonoBehaviour）を既定にする。
+        private static CancellationToken ResolveToken(AssetScopeHolder holder, CancellationToken cancellationToken)
+        {
+            return cancellationToken == default ? holder.destroyCancellationToken : cancellationToken;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Debug/AssetVaultDebugEnvironmentSettings.cs
+++ b/Assets/UniLab/AssetVault/Debug/AssetVaultDebugEnvironmentSettings.cs
@@ -23,7 +23,7 @@ namespace UniLab.AssetVault.Debugging
         // 有効化と選択は UI からは変更させず、コード（Activate/Deactivate）からのみ設定する。
         [SerializeField] private bool _overrideEnabled;
         [SerializeField] private string _selectedPresetName = string.Empty;
-        [SerializeField] private List<AssetVaultDebugEnvironmentPreset> _presets = new List<AssetVaultDebugEnvironmentPreset>();
+        [SerializeField] private List<AssetVaultDebugEnvironmentPreset> _presets = new();
 
         /// <summary>上書きを適用するかどうかです（実機 dev ビルドにも焼き込まれます）。設定は <see cref="Activate"/> / <see cref="Deactivate"/> から行います。</summary>
         public bool OverrideEnabled => _overrideEnabled;

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultDuplicateAddressCollector.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultDuplicateAddressCollector.cs
@@ -10,8 +10,8 @@ namespace UniLab.AssetVault.Editor
     {
         private const string DuplicateAddressLineFormat = "重複アドレス: {0}（{1} と {2}）";
 
-        private readonly Dictionary<string, string> _registeredAssetPathsByAddress = new Dictionary<string, string>();
-        private readonly List<DuplicateAddress> _duplicateAddresses = new List<DuplicateAddress>();
+        private readonly Dictionary<string, string> _registeredAssetPathsByAddress = new();
+        private readonly List<DuplicateAddress> _duplicateAddresses = new();
 
         /// <summary>重複アドレスが1件以上あるかどうかです。</summary>
         public bool HasDuplicates => _duplicateAddresses.Count > 0;

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
@@ -26,7 +26,7 @@ namespace UniLab.AssetVault.Editor
         private static void Open()
         {
             var window = GetWindow<AssetVaultWindow>();
-            window.titleContent = new GUIContent(WindowTitle);
+            window.titleContent = new(WindowTitle);
             window.Show();
         }
 

--- a/Assets/UniLab/AssetVault/Interface/IAssetVaultService.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetVaultService.cs
@@ -21,9 +21,11 @@ namespace UniLab.AssetVault
         Observable<DownloadProgress> OnDownloadProgress { get; }
 
         /// <summary>
-        /// 起動時に配信システムを一度だけ初期化し、catalog と runtime vault service を利用可能にします。
+        /// 起動時に配信システムを一度だけ初期化します。env に対応する <paramref name="baseUrl"/>（env→URL のマッピングはアプリ config が持つ）を受け取り、
+        /// 初期化前に BaseUrl を確定させます。版（ContentPath）は baseUrl の version.json から解決します。
+        /// Debug Override が有効な場合はそちらの BaseUrl を優先します。baseUrl が空なら Local 専用として version 解決をスキップします。
         /// </summary>
-        UniTask InitializeAsync(CancellationToken cancellationToken);
+        UniTask InitializeAsync(string baseUrl, CancellationToken cancellationToken);
 
         /// <summary>
         /// 起動時にリモート catalog の更新を確認し、検出した catalog 変更を適用してから結果を返します。

--- a/Assets/UniLab/AssetVault/Model/AssetVaultState.cs
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultState.cs
@@ -6,6 +6,11 @@ namespace UniLab.AssetVault
     public enum AssetVaultState
     {
         /// <summary>
+        /// 既定値（未設定）。default(AssetVaultState) がこの値になります。
+        /// </summary>
+        None = 0,
+
+        /// <summary>
         /// サービスは起動シーケンスによってまだ初期化されていません。
         /// </summary>
         NotInitialized,

--- a/Assets/UniLab/Sample/AssetVault.meta
+++ b/Assets/UniLab/Sample/AssetVault.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13b830d9c37924ec488384a976355368
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Sample/AssetVault/AssetIconSample.cs
+++ b/Assets/UniLab/Sample/AssetVault/AssetIconSample.cs
@@ -1,0 +1,29 @@
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UniLab.AssetVault.Sample
+{
+    /// <summary>
+    /// Scope も Dispose も CancellationToken も書かない、最小のロードサンプルです。
+    /// this.LoadAssetAsync 拡張により、この GameObject の破棄で読み込んだ asset が自動 Release されます。
+    /// 事前条件: 別途 IAssetVaultService.InitializeAsync 済みであること（アプリ起動シーケンスで実施）。
+    /// </summary>
+    public sealed class AssetIconSample : MonoBehaviour
+    {
+        [SerializeField] private Image _image;
+        [SerializeField] private string _spriteAddress = "Icons/coin";
+
+        private void Start()
+        {
+            ShowAsync().Forget();
+        }
+
+        private async UniTask ShowAsync()
+        {
+            // Scope 不要。ロードは this（GameObject）の寿命に自動で紐づく。
+            // cancellationToken 省略時は destroyCancellationToken が使われ、破棄でロードもキャンセルされる。
+            _image.sprite = await this.LoadAssetAsync<Sprite>(_spriteAddress);
+        }
+    }
+}

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UniLab.AssetVault.Sample
+{
+    /// <summary>
+    /// AssetVault の「初期化 → （任意で更新確認・事前DL）→ ロード → 利用 → 解放」を 1 クラスで示すサンプルです。
+    ///
+    /// 実プロジェクトでの推奨形:
+    ///   - Service（IAssetVaultService）は DI（VContainer）で Singleton 登録し、画面へは注入する。
+    ///   - Scope（IAssetScope）は画面の LifetimeScope に Scoped 登録し、画面破棄＝解放を保証する。
+    /// 本サンプルは自己完結のため Service を直接 new し、解放を MonoBehaviour の寿命（OnDestroy）に合わせています。
+    /// </summary>
+    public sealed class AssetVaultSample : MonoBehaviour
+    {
+        // ロード対象のアドレス。Sync AssetResource 後のアドレス = ルートフォルダ相対・拡張子なし（例 External/Icons/coin.png → "Icons/coin"）。
+        [Header("ロードするアドレス（フォルダ相対・拡張子なし）")]
+        [SerializeField] private string _spriteAddress = "Icons/coin";
+        [SerializeField] private string _prefabAddress = "Enemies/slime";
+
+        // ロード結果の表示先。Inspector で割り当てる。
+        [Header("表示先")]
+        [SerializeField] private Image _iconImage;
+        [SerializeField] private Transform _spawnParent;
+
+        // 配信先の基底 URL。InitializeAsync に渡して初期化前に確定させる。
+        // 実プロジェクトでは env→URL はアプリ config が持つ。Local 同梱のみで試すなら空でよい（version 解決はスキップされる）。
+        [Header("配信先 BaseUrl（Local のみなら空でよい）")]
+        [SerializeField] private string _baseUrl = "";
+
+        // Remote(CDN) アセットの事前ダウンロード対象ラベル。Local 同梱アセットのみを使うなら空でよい。
+        [Header("Remote 事前ダウンロード（任意。ローカルのみなら空でよい）")]
+        [SerializeField] private string[] _preloadLabels = Array.Empty<string>();
+
+        // 自己完結サンプルのため new。実プロジェクトでは IAssetVaultService をコンストラクタ注入する。
+        private readonly AddressablesAssetVaultService _assetVaultService = new();
+
+        // R3 の購読をまとめて破棄するためのコンテナ（OnDestroy で Dispose）。
+        private readonly CompositeDisposable _compositeDisposable = new();
+
+        // 進行中の非同期ロードを画面破棄時にキャンセルするためのトークン源。
+        private readonly CancellationTokenSource _cancellationTokenSource = new();
+
+        // この画面が読み込んだ全アセットの解放を所有するスコープ。Dispose で一括解放。
+        private IAssetScope _assetScope;
+
+        private void Start()
+        {
+            // State は「配信基盤“全体”の状態」を表す（NotInitialized / Initializing / Ready / Downloading / Failed）。
+            // ＝ 起動時の初期化中・一括ダウンロード中・失敗 を示すための“全体ローディング UI”用。
+            // 注意: 個々の LoadAssetAsync / InstantiateAsync 1 件ごとの進行は State には出ない（State は Ready のまま）。
+            //       アセット単体のロード待ちは下の await で扱い、必要ならスピナーを呼び出し側で個別に出す。
+            _assetVaultService.State
+                .Subscribe(state => Debug.Log($"[AssetVault] state = {state}"))
+                .AddTo(_compositeDisposable);
+
+            // 非同期フローを起動。await しないため Forget()（例外は RunAsync 内で処理する）。
+            RunAsync(_cancellationTokenSource.Token).Forget();
+        }
+
+        /// <summary>
+        /// 初期化からロード・表示までの一連フロー。失敗・キャンセルは握って UI へ反映する想定。
+        /// </summary>
+        private async UniTask RunAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // --- 1. 初期化（アプリ起動時に 1 回だけ） ---
+                // BaseUrl を渡して確定 → version.json で版を解決 → Addressables 初期化＋カタログロード。完了で State=Ready。
+                // Debug Override が有効ならそちらの BaseUrl が優先される。
+                await _assetVaultService.InitializeAsync(_baseUrl, cancellationToken);
+
+                // --- 2. 更新確認＋事前ダウンロード（Remote を使う場合のみ。Local 同梱だけなら不要） ---
+                await PreloadRemoteIfNeededAsync(cancellationToken);
+
+                // --- 3. 画面寿命のスコープを作る ---
+                // このスコープ経由で読んだ asset は、scope.Dispose() でまとめて解放される（個別解放は不要）。
+                _assetScope = _assetVaultService.CreateScope();
+
+                // --- 4-a. Sprite をロードして Image に適用 ---
+                // await の完了＝この 1 枚のロード完了。State は使わず await で待つのがアセット単体の流儀。
+                if (_iconImage != null && !string.IsNullOrEmpty(_spriteAddress))
+                {
+                    _iconImage.sprite = await _assetScope.LoadAssetAsync<Sprite>(_spriteAddress, cancellationToken);
+                }
+
+                // --- 4-b. GameObject を生成 ---
+                // InstantiateAsync は「生成（Instantiate）」まで行い、生成したインスタンスの破棄もスコープが所有する。
+                // ＝ scope.Dispose() でインスタンスごと破棄されるため、ここで作った GameObject を手動 Destroy しない。
+                // （プレハブ“資産”だけ欲しく自分で複数 Instantiate したい場合は LoadAssetAsync<GameObject> を使い、
+                //   生成インスタンスは自分で Destroy する。詳細は docs/asset-vault-usage.md 参照。）
+                if (!string.IsNullOrEmpty(_prefabAddress))
+                {
+                    await _assetScope.InstantiateAsync(_prefabAddress, _spawnParent, cancellationToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // 画面破棄（OnDestroy の Cancel）などによる正常キャンセル。ログも不要。
+            }
+            catch (AssetVaultException exception)
+            {
+                // ロード失敗（キー不一致・カタログ未更新・ネットワーク断 等。InnerException に Addressables の元例外）。
+                // 実機ではフォールバック表示やリトライ導線へ繋ぐ。
+                Debug.LogError(exception);
+            }
+        }
+
+        /// <summary>
+        /// 指定 label に未取得分があれば事前ダウンロードします。Remote を使わない（ラベル未指定）場合は何もしません。
+        /// 「サイズ取得 → 確認 → ダウンロード」の判断材料は基盤が返し、確認 UI を出すのはアプリ側の責務です。
+        /// </summary>
+        private async UniTask PreloadRemoteIfNeededAsync(CancellationToken cancellationToken)
+        {
+            // ラベル未指定なら Remote 事前 DL は不要（Local 同梱や都度ロードで足りるケース）。
+            if (_preloadLabels == null || _preloadLabels.Length <= 0)
+            {
+                return;
+            }
+
+            // リモートカタログの更新を確認し、あれば適用（差分の入口）。
+            var update = await _assetVaultService.CheckForUpdatesAsync(cancellationToken);
+            if (update.HasUpdate)
+            {
+                Debug.Log("[AssetVault] catalog updated.");
+            }
+
+            // 未キャッシュ（＝実際に通信が要る）分のサイズ。0 ならダウンロード不要。
+            var sizeBytes = await _assetVaultService.GetDownloadSizeAsync(_preloadLabels, cancellationToken);
+            if (sizeBytes <= 0)
+            {
+                return;
+            }
+
+            // 進捗（0..1）の購読。DownloadAsync 実行中のみ発火するので、ダウンロード直前に購読する。
+            // 実機ではここで「○○MB ダウンロードします」の確認 UI を出してから DownloadAsync する。
+            _assetVaultService.OnDownloadProgress
+                .Subscribe(progress => Debug.Log($"[AssetVault] download {progress.Ratio:P0}"))
+                .AddTo(_compositeDisposable);
+
+            // 依存をまとめて取得。実行中は State=Downloading になり、全体ローディング UI を出せる。
+            await _assetVaultService.DownloadAsync(_preloadLabels, cancellationToken);
+        }
+
+        private void OnDestroy()
+        {
+            // 解放順序が重要:
+            //   1. 進行中ロードをキャンセル（await を OperationCanceledException で抜けさせる）
+            //   2. スコープ破棄でこの画面が読んだ全 asset / 生成 GameObject を一括解放
+            //   3. Service を破棄（State/進捗ストリーム等の内部リソース解放）
+            //   4. 購読をまとめて破棄
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _assetScope?.Dispose();
+            _assetVaultService.Dispose();
+            _compositeDisposable.Dispose();
+        }
+    }
+}

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs
@@ -8,31 +8,32 @@ using UnityEngine.UI;
 namespace UniLab.AssetVault.Sample
 {
     /// <summary>
-    /// AssetVault の「初期化 → （任意で更新確認・事前DL）→ ロード → 利用 → 解放」を 1 クラスで示すサンプルです。
+    /// AssetVault の「初期化 → （任意で更新確認・事前DL）→ ロード → 利用」を 1 クラスで示すサンプルです。
+    /// ロードは this.LoadAssetAsync 拡張を使い、Scope も Dispose も書きません（この GameObject の破棄で asset は自動 Release）。
     ///
     /// 実プロジェクトでの推奨形:
-    ///   - Service（IAssetVaultService）は DI（VContainer）で Singleton 登録し、画面へは注入する。
-    ///   - Scope（IAssetScope）は画面の LifetimeScope に Scoped 登録し、画面破棄＝解放を保証する。
-    /// 本サンプルは自己完結のため Service を直接 new し、解放を MonoBehaviour の寿命（OnDestroy）に合わせています。
+    ///   - Service（IAssetVaultService）は DI（VContainer）で Singleton 登録し、起動シーケンスで InitializeAsync する。
+    ///   - 個々の画面/コンポーネントのロードは this.LoadAssetAsync（破棄連動）で済ませる。
+    /// 本サンプルは自己完結のため Service を直接 new し、初期化フローも内包しています。
     /// </summary>
     public sealed class AssetVaultSample : MonoBehaviour
     {
-        // ロード対象のアドレス。Sync AssetResource 後のアドレス = ルートフォルダ相対・拡張子なし（例 External/Icons/coin.png → "Icons/coin"）。
+        // 配信先の基底 URL。InitializeAsync に渡して初期化前に確定させる。env→URL はアプリ config の責務。
+        // Local 同梱のみで試すなら空でよい（version 解決はスキップされる）。
+        [Header("配信先 BaseUrl（Local のみなら空でよい）")]
+        [SerializeField] private string _baseUrl = "";
+
+        // ロード対象のアドレス（Sync 後のアドレス = ルートフォルダ相対・拡張子なし。例 "Icons/coin"）。
         [Header("ロードするアドレス（フォルダ相対・拡張子なし）")]
         [SerializeField] private string _spriteAddress = "Icons/coin";
         [SerializeField] private string _prefabAddress = "Enemies/slime";
 
-        // ロード結果の表示先。Inspector で割り当てる。
+        // ロード結果の表示先。
         [Header("表示先")]
         [SerializeField] private Image _iconImage;
         [SerializeField] private Transform _spawnParent;
 
-        // 配信先の基底 URL。InitializeAsync に渡して初期化前に確定させる。
-        // 実プロジェクトでは env→URL はアプリ config が持つ。Local 同梱のみで試すなら空でよい（version 解決はスキップされる）。
-        [Header("配信先 BaseUrl（Local のみなら空でよい）")]
-        [SerializeField] private string _baseUrl = "";
-
-        // Remote(CDN) アセットの事前ダウンロード対象ラベル。Local 同梱アセットのみを使うなら空でよい。
+        // Remote(CDN) アセットの事前ダウンロード対象ラベル。Local 同梱のみなら空でよい。
         [Header("Remote 事前ダウンロード（任意。ローカルのみなら空でよい）")]
         [SerializeField] private string[] _preloadLabels = Array.Empty<string>();
 
@@ -42,24 +43,17 @@ namespace UniLab.AssetVault.Sample
         // R3 の購読をまとめて破棄するためのコンテナ（OnDestroy で Dispose）。
         private readonly CompositeDisposable _compositeDisposable = new();
 
-        // 進行中の非同期ロードを画面破棄時にキャンセルするためのトークン源。
-        private readonly CancellationTokenSource _cancellationTokenSource = new();
-
-        // この画面が読み込んだ全アセットの解放を所有するスコープ。Dispose で一括解放。
-        private IAssetScope _assetScope;
-
         private void Start()
         {
-            // State は「配信基盤“全体”の状態」を表す（NotInitialized / Initializing / Ready / Downloading / Failed）。
-            // ＝ 起動時の初期化中・一括ダウンロード中・失敗 を示すための“全体ローディング UI”用。
-            // 注意: 個々の LoadAssetAsync / InstantiateAsync 1 件ごとの進行は State には出ない（State は Ready のまま）。
-            //       アセット単体のロード待ちは下の await で扱い、必要ならスピナーを呼び出し側で個別に出す。
+            // State は「配信基盤“全体”の状態」（NotInitialized / Initializing / Ready / Downloading / Failed）。
+            // ＝ 起動時の初期化中・一括ダウンロード中・失敗 を示す“全体ローディング UI”用。
+            // 注意: 個々のロード 1 件ごとの進行は State に出ない（State は Ready のまま）。アセット単体は await で待つ。
             _assetVaultService.State
                 .Subscribe(state => Debug.Log($"[AssetVault] state = {state}"))
                 .AddTo(_compositeDisposable);
 
-            // 非同期フローを起動。await しないため Forget()（例外は RunAsync 内で処理する）。
-            RunAsync(_cancellationTokenSource.Token).Forget();
+            // destroyCancellationToken を使うので、画面破棄でフロー（と各ロード）が自動キャンセルされる。
+            RunAsync(destroyCancellationToken).Forget();
         }
 
         /// <summary>
@@ -70,53 +64,44 @@ namespace UniLab.AssetVault.Sample
             try
             {
                 // --- 1. 初期化（アプリ起動時に 1 回だけ） ---
-                // BaseUrl を渡して確定 → version.json で版を解決 → Addressables 初期化＋カタログロード。完了で State=Ready。
+                // BaseUrl を渡して確定 → version.json で版を解決 → Addressables 初期化＋カタログロード。
                 // Debug Override が有効ならそちらの BaseUrl が優先される。
                 await _assetVaultService.InitializeAsync(_baseUrl, cancellationToken);
 
-                // --- 2. 更新確認＋事前ダウンロード（Remote を使う場合のみ。Local 同梱だけなら不要） ---
+                // --- 2. 更新確認＋事前ダウンロード（Remote を使う場合のみ） ---
                 await PreloadRemoteIfNeededAsync(cancellationToken);
 
-                // --- 3. 画面寿命のスコープを作る ---
-                // このスコープ経由で読んだ asset は、scope.Dispose() でまとめて解放される（個別解放は不要）。
-                _assetScope = _assetVaultService.CreateScope();
-
-                // --- 4-a. Sprite をロードして Image に適用 ---
-                // await の完了＝この 1 枚のロード完了。State は使わず await で待つのがアセット単体の流儀。
+                // --- 3. ロードして利用（Scope を書かない） ---
+                // this.LoadAssetAsync は この GameObject に紐づくスコープを裏で使い、破棄時に自動 Release する。
+                // ＝ CreateScope / Dispose を書かなくてよい。
                 if (_iconImage != null && !string.IsNullOrEmpty(_spriteAddress))
                 {
-                    _iconImage.sprite = await _assetScope.LoadAssetAsync<Sprite>(_spriteAddress, cancellationToken);
+                    _iconImage.sprite = await this.LoadAssetAsync<Sprite>(_spriteAddress, cancellationToken);
                 }
 
-                // --- 4-b. GameObject を生成 ---
-                // InstantiateAsync は「生成（Instantiate）」まで行い、生成したインスタンスの破棄もスコープが所有する。
-                // ＝ scope.Dispose() でインスタンスごと破棄されるため、ここで作った GameObject を手動 Destroy しない。
-                // （プレハブ“資産”だけ欲しく自分で複数 Instantiate したい場合は LoadAssetAsync<GameObject> を使い、
-                //   生成インスタンスは自分で Destroy する。詳細は docs/asset-vault-usage.md 参照。）
+                // 生成も同様。生成物の破棄もこの GameObject の破棄に連動する（手動 Destroy しない）。
                 if (!string.IsNullOrEmpty(_prefabAddress))
                 {
-                    await _assetScope.InstantiateAsync(_prefabAddress, _spawnParent, cancellationToken);
+                    await this.InstantiateAsync(_prefabAddress, _spawnParent, cancellationToken);
                 }
             }
             catch (OperationCanceledException)
             {
-                // 画面破棄（OnDestroy の Cancel）などによる正常キャンセル。ログも不要。
+                // 画面破棄（destroyCancellationToken）などによる正常キャンセル。
             }
             catch (AssetVaultException exception)
             {
                 // ロード失敗（キー不一致・カタログ未更新・ネットワーク断 等。InnerException に Addressables の元例外）。
-                // 実機ではフォールバック表示やリトライ導線へ繋ぐ。
                 Debug.LogError(exception);
             }
         }
 
         /// <summary>
-        /// 指定 label に未取得分があれば事前ダウンロードします。Remote を使わない（ラベル未指定）場合は何もしません。
+        /// 指定 label に未取得分があれば事前ダウンロードします。ラベル未指定なら何もしません。
         /// 「サイズ取得 → 確認 → ダウンロード」の判断材料は基盤が返し、確認 UI を出すのはアプリ側の責務です。
         /// </summary>
         private async UniTask PreloadRemoteIfNeededAsync(CancellationToken cancellationToken)
         {
-            // ラベル未指定なら Remote 事前 DL は不要（Local 同梱や都度ロードで足りるケース）。
             if (_preloadLabels == null || _preloadLabels.Length <= 0)
             {
                 return;
@@ -148,14 +133,8 @@ namespace UniLab.AssetVault.Sample
 
         private void OnDestroy()
         {
-            // 解放順序が重要:
-            //   1. 進行中ロードをキャンセル（await を OperationCanceledException で抜けさせる）
-            //   2. スコープ破棄でこの画面が読んだ全 asset / 生成 GameObject を一括解放
-            //   3. Service を破棄（State/進捗ストリーム等の内部リソース解放）
-            //   4. 購読をまとめて破棄
-            _cancellationTokenSource.Cancel();
-            _cancellationTokenSource.Dispose();
-            _assetScope?.Dispose();
+            // ロードした asset / 生成物は this.LoadAssetAsync 拡張により GameObject 破棄で自動解放されるため、ここでは扱わない。
+            // 自己完結のため new した Service（State/進捗ストリーム）と、購読だけを破棄する。
             _assetVaultService.Dispose();
             _compositeDisposable.Dispose();
         }

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs.meta
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae486d15cb8274d29879be7b9333cdb8

--- a/Assets/UniLab/Sample/AssetVault/UniLab.AssetVault.Sample.asmdef
+++ b/Assets/UniLab/Sample/AssetVault/UniLab.AssetVault.Sample.asmdef
@@ -1,0 +1,19 @@
+{
+    "name": "UniLab.AssetVault.Sample",
+    "rootNamespace": "",
+    "references": [
+        "UniLab.AssetVault",
+        "GUID:77221876cc6b8244180b96e320b1bcd4",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "UnityEngine.UI"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/UniLab/Sample/AssetVault/UniLab.AssetVault.Sample.asmdef.meta
+++ b/Assets/UniLab/Sample/AssetVault/UniLab.AssetVault.Sample.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 909935b484c974fb28f51edb721f7609
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/docs/asset-vault-getting-started.md
+++ b/docs/asset-vault-getting-started.md
@@ -1,0 +1,192 @@
+# AssetVault はじめかた（Getting Started）
+
+導入からアプリで最初の 1 枚を表示するまでを、順番にたどる手引き。
+- 仕様・API の俯瞰／運用 → [asset-vault-guide.md](asset-vault-guide.md)
+- ロード・利用・解放の詳細コード → [asset-vault-usage.md](asset-vault-usage.md)
+- 配信設計（version.json / CDN） → [design-unilab-asset-cdn.md](design-unilab-asset-cdn.md)
+
+AssetVault は Addressables をアプリ層から隠す配信基盤。アプリは `IAssetVaultService` と `IAssetScope` だけを使う。
+
+---
+
+## 全体像（5 ステップ）
+
+```
+[1] エディタでセットアップ   … フォルダ → Addressables 構成（Dashboard / Sync）
+[2] ビルド                   … New Build（差分は Content Update）
+[3] DI 登録                  … Service=Singleton / Scope=Scoped
+[4] 起動フロー               … Initialize → 更新確認 → 事前DL
+[5] 画面でロード/利用/解放    … CreateScope → LoadAssetAsync → Dispose
+```
+
+[1][2] はエディタ作業（初回・アセット変更時）。[3][4][5] が実装。
+
+---
+
+## [1] セットアップ（エディタ）
+
+1. `UniLab > AssetVault > Dashboard` を開く
+2. **Setup** の `Open Setup Settings` で設定アセットを開く
+3. **Local Folder（必須）** と **Remote Folder（任意）** にフォルダをドラッグ
+   - Local = プレイヤー同梱、Remote = CDN 配信。フォルダ名は分類に無関係（スロットで決まる）
+   - 各フォルダ直下のサブフォルダが Addressables グループ `Local_<名>` / `Remote_<名>` になる
+4. 設定アセットの **`Sync AssetResource`** ボタンを押す
+   - グループ・アドレス・プロファイルパスが自動構成される
+   - アドレス = フォルダ相対・拡張子なし（例 `External/Icons/coin.png` → `Icons/coin`）
+   - 重複アドレスがあると失敗するので解消して再実行
+
+詳細・規約は [asset-vault-guide.md](asset-vault-guide.md) の「同期対象フォルダ」。
+
+## [2] ビルド（エディタ）
+
+Dashboard の **Build**：
+- **New Build** … フルビルド。初回・グループ構成変更時。`content_state.bin` が出る（リリースごとに保管）
+- **Content Update (Diff)** … 保管した state を基準に差分だけ再ビルド（配信済みアプリ向け）
+
+---
+
+## [3] DI 登録（VContainer）
+
+Service は Singleton、Scope は画面の LifetimeScope で Scoped 登録。Scoped の Dispose ＝ 画面破棄でアセット解放が保証される。
+
+```csharp
+// RootLifetimeScope
+builder.Register<IAssetVaultService, AddressablesAssetVaultService>(Lifetime.Singleton);
+
+// SceneLifetimeScope（画面）
+builder.Register(resolver =>
+        resolver.Resolve<IAssetVaultService>().CreateScope(),
+    Lifetime.Scoped);
+```
+
+## [4] 起動フロー
+
+起動時に一度だけ初期化し、必要なら更新確認・事前ダウンロード。確認ダイアログや進捗 UI はアプリ層の責務（基盤は判断材料を返すだけ）。
+
+```csharp
+// baseUrl = env→URL（アプリ config が解決）。初期化前に BaseUrl を確定し、版は version.json 解決に任せる。
+// Debug Override 有効時はそちらが優先。Local 専用なら baseUrl は空でよい。
+await _assetVault.InitializeAsync(config.AssetBaseUrl, cancellationToken);
+
+var update = await _assetVault.CheckForUpdatesAsync(cancellationToken);
+if (update.HasUpdate)
+{
+    var labels = new[] { "preload" };
+    var sizeBytes = await _assetVault.GetDownloadSizeAsync(labels, cancellationToken);
+    if (sizeBytes > 0)
+    {
+        // 「○○MB ダウンロードします」確認 UI を出してから
+        await _assetVault.DownloadAsync(labels, cancellationToken);
+    }
+}
+```
+
+状態・進捗はリアクティブに購読：
+
+```csharp
+_assetVault.State
+    .Subscribe(state => _loadingView.SetVisible(state == AssetVaultState.Downloading))
+    .AddTo(_disposables);
+
+_assetVault.OnDownloadProgress
+    .Subscribe(progress => _progressBar.Value = progress.Ratio)
+    .AddTo(_disposables);
+```
+
+## [5] 画面でロード・利用・解放
+
+### 標準: Component 拡張（Scope を書かない・推奨）
+
+```csharp
+public sealed class IconView : MonoBehaviour
+{
+    [SerializeField] private Image _image;
+
+    private async UniTask ShowAsync()
+    {
+        // Scope/Dispose/CancellationToken 不要。この GameObject の破棄で自動 Release。
+        _image.sprite = await this.LoadAssetAsync<Sprite>("Icons/coin");
+    }
+}
+```
+
+### 上位: 明示 Scope（画面単位で一括・共有寿命）
+
+```csharp
+_assetScope = assetVaultService.CreateScope();
+var icon = await _assetScope.LoadAssetAsync<Sprite>("Icons/coin", cancellationToken);
+// InstantiateAsync も同様。画面破棄で _assetScope.Dispose() → 一括解放
+```
+
+**詳細（使い分け、2 パターンの GameObject、解放の落とし穴、キャンセル/例外）は [asset-vault-usage.md](asset-vault-usage.md) を参照。**
+
+---
+
+## 環境・版の切り替え（QA）
+
+- 環境は `InitializeAsync(baseUrl, ct)` に渡す baseUrl（env→URL はアプリ config）で切替。版は `version.json` 解決。
+- QA で別環境を見る場合は **Debug Override**：プリセットの BaseUrl のみ上書き（版は version.json 任せ）。有効化・選択はコード／`UniLab/AssetVault/Debug/Select Environment...` メニュー経由。development ビルドのみ有効・release はストリップ。詳細は [asset-vault-guide.md](asset-vault-guide.md) の「環境切り替え」。
+
+---
+
+## つまずきポイント
+
+| 症状 | 原因/対処 |
+|---|---|
+| `Sync` が中断する | Local Folder 未設定（必須）。設定アセットで指定する |
+| `Sync` が失敗（重複アドレス） | 別アセットが同一アドレス（フォルダ相対・拡張子なし）に衝突。フォルダ構成を見直す |
+| ロードで `AssetVaultException` | キー不一致／カタログ未更新／ネットワーク。key=アドレスを確認、`CheckForUpdatesAsync` 済みか確認 |
+| Remote が初回だけ遅い | 未キャッシュ。`DownloadAsync` で事前取得 |
+| `Dispose` 後に絵が消える/エラー | 解放後にアセット参照を使っている。参照を残さない |
+| 生成物が二重破棄/警告 | `InstantiateAsync` の生成物を手動 `Destroy` している。スコープに任せる |
+
+---
+
+## 最小サンプル（Presenter）
+
+```csharp
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Game.Title
+{
+    /// <summary>タイトル画面。AssetVault からロゴをロードして表示し、破棄で解放する。</summary>
+    public sealed class TitlePresenter : IDisposable
+    {
+        private readonly IAssetScope _assetScope;
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        public TitlePresenter(IAssetVaultService assetVaultService, Image logoImage)
+        {
+            _assetScope = assetVaultService.CreateScope();
+            LoadAsync(logoImage, _cancellationTokenSource.Token).Forget();
+        }
+
+        private async UniTask LoadAsync(Image logoImage, CancellationToken cancellationToken)
+        {
+            try
+            {
+                logoImage.sprite = await _assetScope.LoadAssetAsync<Sprite>("title_logo", cancellationToken);
+            }
+            catch (OperationCanceledException)
+            {
+                // 画面破棄による正常キャンセル
+            }
+            catch (AssetVaultException exception)
+            {
+                Debug.LogError(exception);
+            }
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _assetScope.Dispose();
+        }
+    }
+}
+```

--- a/docs/asset-vault-guide.md
+++ b/docs/asset-vault-guide.md
@@ -43,7 +43,7 @@ Addressables の生 API をアプリ層から隠蔽する配信基盤 `UniLab.As
 |---|---|
 | `State` | `ReadOnlyReactiveProperty<AssetVaultState>`。ローディング UI の出し分けに購読する |
 | `OnDownloadProgress` | `Observable<DownloadProgress>`。`DownloadAsync` 実行中のみ発火。OnError は流さない |
-| `InitializeAsync` | 起動時に1回。Addressables 初期化 + カタログロード |
+| `InitializeAsync(baseUrl, ct)` | 起動時に1回。baseUrl を確定→version.json で版解決→Addressables 初期化 + カタログロード（Debug Override 優先、baseUrl 空は Local 専用） |
 | `CheckForUpdatesAsync` | カタログ更新確認 → 更新があれば適用し `CatalogUpdateInfo` を返す |
 | `GetDownloadSizeAsync` | ラベル群の未取得分サイズ。0 ならダウンロード不要 |
 | `DownloadAsync` | ラベル群の事前ダウンロード。進捗は `OnDownloadProgress` で通知 |
@@ -92,7 +92,9 @@ builder.Register(resolver =>
 確認ダイアログ・進捗 UI はアプリ層の責務。基盤は判断材料（サイズ・進捗）を返すだけ。
 
 ```csharp
-await _assetVault.InitializeAsync(cancellationToken);
+// baseUrl は env→URL（アプリ config が解決）。初期化前に BaseUrl を確定し、版は version.json で解決される。
+// Debug Override 有効時はそちらの BaseUrl が優先。Local 専用なら baseUrl は空でよい。
+await _assetVault.InitializeAsync(config.AssetBaseUrl, cancellationToken);
 
 var update = await _assetVault.CheckForUpdatesAsync(cancellationToken);
 if (update.HasUpdate)

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -1,0 +1,247 @@
+# AssetVault 利用ガイド：アセットのロード・利用・解放
+
+`IAssetVaultService` / `IAssetScope` を使って Sprite・GameObject などを読み込み、使い、解放するまでの実コード手引き。
+API 仕様の俯瞰は [asset-vault-guide.md](asset-vault-guide.md)、配信設計は [design-unilab-asset-cdn.md](design-unilab-asset-cdn.md) を参照。
+
+---
+
+## 2 つの使い方（標準 / 上位）
+
+| 方式 | 書き方 | 解放タイミング | 使うとき |
+|---|---|---|---|
+| **標準: Component 拡張** | `this.LoadAssetAsync<T>(key)` | **その GameObject の破棄で自動** | 単一コンポーネントが自分用の asset を読む大半のケース |
+| **上位: 明示 Scope** | `scope.LoadAssetAsync<T>(key, ct)` | `scope.Dispose()`（画面/シーン単位で一括） | 複数 View をまたいでまとめたい・共有寿命を制御したい |
+
+迷ったら**標準（拡張）**。Scope も Dispose も書かずに済む。
+
+### 標準: `this.LoadAssetAsync`（推奨・最小）
+
+```csharp
+public sealed class IconView : MonoBehaviour
+{
+    [SerializeField] private Image _image;
+
+    private async UniTask ShowAsync()
+    {
+        // Scope/Dispose/CancellationToken を書かない。GameObject 破棄で自動 Release。
+        // ct 省略時は destroyCancellationToken が使われ、ロード中キャンセルも自動。
+        _image.sprite = await this.LoadAssetAsync<Sprite>("Icons/coin");
+    }
+}
+```
+
+- 裏で GameObject に隠しスコープ（`AssetScopeHolder`）が付き、`OnDestroy` で解放される。アプリは触らない。
+- `this.InstantiateAsync(key, parent)` も同様（生成物も GameObject 破棄で解放）。
+- 前提: 別途 `IAssetVaultService.InitializeAsync` 済みであること（起動シーケンス）。
+
+> 以降は **上位: 明示 Scope** 方式の説明。共有寿命や画面単位の一括解放が要るときに使う。
+
+## 明示 Scope の原則（最初に押さえる3点）
+
+1. **ロードは必ず `IAssetScope` 経由**で行う。`Addressables` を直接触らない（拡張も裏で Scope を使う）。
+2. **スコープが asset の lifetime を所有する**。画面/シーン単位で 1 スコープを作り、`Dispose()` で**その画面で読んだ全アセットを一括解放**する。個別解放は不要。
+3. **解放後（`Dispose()` 後）にアセットへアクセスしない**。Sprite/Prefab は解放でアンロードされ得るため、参照を残して使うとリークや不正参照になる。
+
+> `key` は Addressables の **アドレス**（= ルートフォルダ相対・拡張子なし。例 `Characters/hero`）。
+
+---
+
+## 公開 API（ロード関連の抜粋）
+
+```csharp
+public interface IAssetVaultService
+{
+    IAssetScope CreateScope();                       // 画面/シーン単位のスコープを作る
+    // …Initialize / Download などは asset-vault-guide.md 参照
+}
+
+public interface IAssetScope : IDisposable
+{
+    // key で asset をロード（Sprite / ScriptableObject / GameObject(プレハブ資産) 等）
+    UniTask<T> LoadAssetAsync<T>(string key, CancellationToken cancellationToken);
+
+    // key の GameObject を parent 配下に生成（インスタンス化まで行う）
+    UniTask<GameObject> InstantiateAsync(string key, Transform parent, CancellationToken cancellationToken);
+}
+```
+
+---
+
+## 1. スコープの生成と破棄（土台）
+
+スコープは「画面（Presenter）やシーンの寿命」と一致させる。Presenter なら `Dispose` パターンに乗せる。
+
+```csharp
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+
+namespace Game.Title
+{
+    /// <summary>
+    /// タイトル画面の Presenter。画面寿命に合わせて AssetVault のスコープを所有・解放する。
+    /// </summary>
+    public sealed class TitlePresenter : System.IDisposable
+    {
+        private readonly IAssetScope _assetScope;
+        private readonly CompositeDisposable _compositeDisposable = new CompositeDisposable();
+        private readonly CancellationTokenSource _cancellationTokenSource = new CancellationTokenSource();
+
+        public TitlePresenter(IAssetVaultService assetVaultService)
+        {
+            // 画面で 1 つだけスコープを作る。以降のロードはすべてこのスコープ経由。
+            _assetScope = assetVaultService.CreateScope();
+        }
+
+        public void Dispose()
+        {
+            // 進行中のロードをキャンセル → スコープ破棄で全 handle を解放。
+            _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Dispose();
+            _assetScope.Dispose();        // ← ここで読み込んだ Sprite/GameObject がまとめて解放される
+            _compositeDisposable.Dispose();
+        }
+    }
+}
+```
+
+- **1 画面 = 1 スコープ**。複数画面で使い回さない（解放境界が曖昧になる）。
+- `Dispose()` を必ず呼ぶ（MVP の Presenter 破棄、VContainer の LifetimeScope 破棄、`MonoBehaviour.OnDestroy` 等に紐付ける）。
+
+---
+
+## 2. Sprite を読み込んで Image に表示する
+
+```csharp
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// アイコン Sprite をロードして Image に適用する。
+/// </summary>
+private async UniTask LoadIconAsync(Image targetImage, CancellationToken cancellationToken)
+{
+    // key はアドレス（例: External/Icons/coin.png → "Icons/coin"）
+    var sprite = await _assetScope.LoadAssetAsync<Sprite>("Icons/coin", cancellationToken);
+    targetImage.sprite = sprite;
+}
+```
+
+呼び出し側：
+
+```csharp
+LoadIconAsync(_view.IconImage, _cancellationTokenSource.Token).Forget();
+```
+
+注意：
+- `targetImage.sprite` に入れた Sprite は、**スコープ破棄まで有効**。`Dispose()` 後は `targetImage.sprite` を参照したままにしない（破棄前に `null` 代入など）。
+- 同じ key を 2 回 `LoadAssetAsync` してもアドレッサブルが参照カウントで管理する。スコープが両方の handle を持ち、Dispose でまとめて解放する。
+
+---
+
+## 3. GameObject の読み込み：2 パターンを使い分ける
+
+### A. その場に生成したい → `InstantiateAsync`（推奨）
+
+生成（Instantiate）まで行い、**生成したインスタンスの解放もスコープが所有**する。
+
+```csharp
+/// <summary>
+/// 敵プレハブを生成して配置する。生成物の破棄はスコープ Dispose に任せる。
+/// </summary>
+private async UniTask<GameObject> SpawnEnemyAsync(Transform parent, CancellationToken cancellationToken)
+{
+    var enemy = await _assetScope.InstantiateAsync("Enemies/slime", parent, cancellationToken);
+    return enemy;
+}
+```
+
+- **生成した GameObject を自分で `Object.Destroy` しない**。`scope.Dispose()` 時に Addressables がインスタンスを破棄＋解放する。
+- 画面の途中で個別に消したい一過性の生成物は、このスコープ方式に乗せず別管理を検討（このスコープは「画面寿命で一括解放」用途）。
+
+### B. プレハブ資産だけ欲しい（自前で複数 Instantiate する等）→ `LoadAssetAsync<GameObject>`
+
+```csharp
+// プレハブ「資産」をロード（インスタンス化はしない）
+var prefab = await _assetScope.LoadAssetAsync<GameObject>("Bullets/normal", cancellationToken);
+
+// 自分で Instantiate する場合、生成インスタンスの寿命は「自分の責任」
+var bullet = Object.Instantiate(prefab, parent);
+// … 使い終わったら自分で Object.Destroy(bullet);
+// プレハブ資産そのもの（prefab）は scope.Dispose() で解放される
+```
+
+- こちらは **生成インスタンスはスコープ管理外**。`Object.Instantiate` した分は自分で `Destroy` する。スコープが解放するのは「プレハブ資産の handle」だけ。
+- 迷ったら **A（InstantiateAsync）** を使う方が解放漏れしにくい。
+
+---
+
+## 4. 解放（Release）の仕方
+
+**個別解放 API は無い。スコープの `Dispose()` が唯一の解放手段。**
+
+```csharp
+_assetScope.Dispose();
+// → このスコープで LoadAssetAsync / InstantiateAsync した全 handle を Addressables.Release で解放
+//   - LoadAssetAsync 分: 参照カウントを減らし、0 でアンロード
+//   - InstantiateAsync 分: 生成インスタンスを破棄して解放
+```
+
+やってはいけないこと：
+- ❌ `Dispose()` 後に Sprite / プレハブ / 生成 GameObject を使う
+- ❌ `InstantiateAsync` で作った GameObject を手動 `Object.Destroy`（二重解放・警告の原因）
+- ❌ スコープを跨いでアセット参照を共有（解放境界が壊れる）
+
+---
+
+## 5. キャンセルと例外
+
+- 各 API は `CancellationToken` を取る。画面破棄時は `CancellationTokenSource.Cancel()` でロード中処理を中断する（上の Presenter 例）。
+- ロード失敗時は `AssetVaultException` が飛ぶ（キャンセルは `OperationCanceledException`）。表示の出し分けは呼び出し側で行う。
+
+```csharp
+try
+{
+    var sprite = await _assetScope.LoadAssetAsync<Sprite>("Icons/coin", cancellationToken);
+    _view.IconImage.sprite = sprite;
+}
+catch (System.OperationCanceledException)
+{
+    // 画面破棄などによる正常キャンセル。握りつぶしてよい。
+}
+catch (AssetVaultException exception)
+{
+    // ロード失敗（キー不一致・ネットワーク・カタログ不整合等）。フォールバック表示やリトライ導線へ。
+    Debug.LogError(exception);
+}
+```
+
+---
+
+## 6. Remote アセットは事前ダウンロードが要る場合がある
+
+Remote（CDN 配信）アセットは、未キャッシュだと初回 `LoadAssetAsync` で都度 DL になる。まとまった量は **`DownloadAsync` で事前取得**してから使うと UX が安定する（label 単位）。詳細は [asset-vault-guide.md](asset-vault-guide.md) の「差分配信の運用」。
+
+```csharp
+var labels = new[] { "stage1" };
+var size = await assetVaultService.GetDownloadSizeAsync(labels, cancellationToken);
+if (size > 0)
+{
+    // 必要なら size を見て確認ダイアログ → DownloadAsync（進捗は OnDownloadProgress を購読）
+    await assetVaultService.DownloadAsync(labels, cancellationToken);
+}
+// 以降のロードはキャッシュから即時
+```
+
+---
+
+## まとめ（チェックリスト）
+
+- [ ] 画面/シーンごとに `CreateScope()` で 1 スコープを作った
+- [ ] ロードは `LoadAssetAsync<T>` / `InstantiateAsync` のみ（`Addressables` 直叩きしない）
+- [ ] 生成物は `InstantiateAsync`（推奨）。`LoadAssetAsync<GameObject>` から自前 Instantiate した分は自分で Destroy
+- [ ] 画面破棄で `CancellationTokenSource.Cancel()` → `scope.Dispose()` を呼んだ
+- [ ] `Dispose()` 後にアセット参照を使っていない


### PR DESCRIPTION
## 概要
アセットのロードを「Scope を書かない」体験にし、初期化時に URL を確定する形へ整理。

## 主な変更
- **Component 拡張ロード**: `this.LoadAssetAsync<T>(key)` / `this.InstantiateAsync(key, parent)` を追加。呼び出し元 GameObject の破棄で Addressables を自動 Release。ct 省略時は `destroyCancellationToken`。
- **隠し `AssetScopeHolder`**: GameObject 寿命にスコープを紐付け（裏で従来の `IAssetScope` を使用＝「Addressables 直叩き禁止」原則は維持）。
- **`InitializeAsync(baseUrl, ct)` 化**: 初期化前に BaseUrl を確定 → version.json で版（ContentPath）を解決 → Addressables 初期化。Debug Override 有効時はそちらを優先。baseUrl 空は Local 専用（version 解決スキップ）。
- **C# 規約**: `AssetVaultState` に既定値 `None` を追加、対象箇所を target-typed `new()` 化。
- **サンプル**: `AssetVaultSample`（初期化＋任意DL＋拡張ロードの全体像）/ `AssetIconSample`（`this.LoadAssetAsync` 最小例）。
- **ドキュメント**: `asset-vault-getting-started.md` / `asset-vault-usage.md` を追加、`asset-vault-guide.md` を更新。「標準＝拡張 / 上位＝明示 Scope」の使い分けを明記。

## 確認
- Unity でコンパイル通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)