### PR TITLE
AssetVault: 共有キャッシュ(refcount+TTL/LRU)・スロット・プールサンプル＋Interface 整理

### DIFF
--- a/Assets/UniLab/AssetVault/AssetSlot.cs
+++ b/Assets/UniLab/AssetVault/AssetSlot.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 「1 つのアセットを差し込むスロット」です。<see cref="SetAsync"/> で key を差し替えると、
+    /// 旧アセットを解放してから新アセットを取得します（常に最大1参照しか持たないため溜まりません）。
+    /// オブジェクトプール要素のように「再利用ごとに表示アセットが変わる」ケースで、スコープ手動管理の代わりに使います。
+    /// Dispose で現在の参照を解放します。<see cref="IAssetVaultCache"/> 経由なので共有・遅延解放（TTL/LRU）の恩恵も受けます。
+    /// </summary>
+    public sealed class AssetSlot<T> : IDisposable
+    {
+        private readonly IAssetVaultCache _cache;
+        private IAssetReference<T> _current;
+        private string _currentKey;
+        private CancellationTokenSource _cancellationTokenSource;
+
+        public AssetSlot(IAssetVaultCache cache)
+        {
+            _cache = cache;
+        }
+
+        /// <summary>現在保持しているアセット。未設定時は default。</summary>
+        public T Value => _current != null ? _current.Value : default;
+
+        /// <summary>
+        /// スロットの key を差し替えます。同じ key なら何もしません。空 key はクリア（解放のみ）。
+        /// 連続呼び出しは前回の取得をキャンセルして最新だけを反映します。
+        /// </summary>
+        public async UniTask<T> SetAsync(string key, CancellationToken cancellationToken = default)
+        {
+            if (_currentKey == key)
+            {
+                return Value;
+            }
+
+            // 前回の進行中 SetAsync をキャンセルし、今回分のトークンを用意する。
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            var token = _cancellationTokenSource.Token;
+
+            // 旧参照を即解放（参照カウントを手放す。キャッシュ側で TTL 猶予保持される）。
+            _current?.Dispose();
+            _current = null;
+            _currentKey = key;
+
+            if (string.IsNullOrEmpty(key))
+            {
+                return default;
+            }
+
+            var reference = await _cache.AcquireAsync<T>(key, token);
+
+            // await 中にさらに差し替えられた/破棄された場合は、取得分を捨てて最新を尊重する。
+            if (token.IsCancellationRequested)
+            {
+                reference.Dispose();
+                return default;
+            }
+
+            _current = reference;
+            return reference.Value;
+        }
+
+        /// <summary>現在のアセットを解放してスロットを空にします。</summary>
+        public void Clear()
+        {
+            _current?.Dispose();
+            _current = null;
+            _currentKey = null;
+        }
+
+        public void Dispose()
+        {
+            _cancellationTokenSource?.Cancel();
+            _cancellationTokenSource?.Dispose();
+            _cancellationTokenSource = null;
+            Clear();
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetSlot.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetSlot.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 86338a2a03786497eabb29a8f350c42a

--- a/Assets/UniLab/AssetVault/AssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCache.cs
@@ -1,0 +1,252 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.AddressableAssets;
+using UnityEngine.ResourceManagement.AsyncOperations;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 参照カウント＋TTL/LRU でアセットを共有・遅延解放する <see cref="IAssetVaultCache"/> の Addressables 実装です。
+    /// 同一スレッド（メインスレッド）からの利用を前提とします。
+    /// </summary>
+    public sealed class AssetVaultCache : IAssetVaultCache, IDisposable
+    {
+        private readonly AssetVaultCacheSettings _settings;
+        private readonly Func<float> _timeProvider;
+        private readonly Dictionary<CacheKey, Entry> _entries = new();
+        private readonly List<CacheKey> _reclaimBuffer = new();
+
+        /// <summary>
+        /// 設定（既定は <see cref="AssetVaultCacheSettings.Default"/>）と時刻プロバイダ（既定は realtimeSinceStartup）でキャッシュを作成します。
+        /// timeProvider はテストで時間を制御するために差し替え可能です。
+        /// </summary>
+        public AssetVaultCache(AssetVaultCacheSettings settings = default, Func<float> timeProvider = null)
+        {
+            // default(struct) は TTL=0/Capacity=0 になるため、未指定は Default を採用する。
+            _settings = settings.TtlSeconds <= 0f && settings.Capacity <= 0 ? AssetVaultCacheSettings.Default : settings;
+            _timeProvider = timeProvider ?? (() => Time.realtimeSinceStartup);
+        }
+
+        /// <inheritdoc />
+        public async UniTask<IAssetReference<T>> AcquireAsync<T>(string key, CancellationToken cancellationToken)
+        {
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new AssetVaultException("AssetVaultCache.AcquireAsync: key is null or empty.");
+            }
+
+            SweepExpired();
+
+            var cacheKey = new CacheKey(key, typeof(T));
+            if (!_entries.TryGetValue(cacheKey, out var entry))
+            {
+                AsyncOperationHandle handle = Addressables.LoadAssetAsync<T>(key);
+                entry = new Entry(handle);
+                _entries.Add(cacheKey, entry);
+            }
+
+            entry.RefCount++;
+
+            try
+            {
+                await entry.Handle.ToUniTask(cancellationToken: cancellationToken);
+                AssetVaultOperationGuard.ThrowIfFailed(entry.Handle, $"Failed to load asset by key '{key}'.");
+            }
+            catch (Exception exception)
+            {
+                // この Acquire 分を取り消す。失敗ロードは TTL を待たず即破棄する。
+                entry.RefCount--;
+                if (entry.RefCount <= 0)
+                {
+                    ReleaseEntry(cacheKey, entry);
+                }
+
+                if (exception is OperationCanceledException)
+                {
+                    throw;
+                }
+
+                throw AssetVaultOperationGuard.ToAssetVaultException(exception, $"Failed to load asset by key '{key}'.");
+            }
+
+            EnforceCapacity();
+            return new AssetReference<T>(this, cacheKey, (T)entry.Handle.Result);
+        }
+
+        /// <inheritdoc />
+        public void Trim()
+        {
+            SweepExpired();
+            EnforceCapacity();
+        }
+
+        /// <summary>
+        /// 全エントリを参照カウントに関わらず解放します。
+        /// </summary>
+        public void Dispose()
+        {
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.Handle.IsValid())
+                {
+                    Addressables.Release(pair.Value.Handle);
+                }
+            }
+
+            _entries.Clear();
+        }
+
+        // 参照を 1 つ手放す。0 になったら TTL に従い、TTL<=0 なら即解放、それ以外は猶予のため保持する。
+        // 入れ子の AssetReference から呼ぶ（入れ子型は外側の private にアクセス可能）。
+        private void ReleaseInternal(CacheKey cacheKey)
+        {
+            if (!_entries.TryGetValue(cacheKey, out var entry))
+            {
+                return;
+            }
+
+            entry.RefCount--;
+            if (entry.RefCount > 0)
+            {
+                return;
+            }
+
+            entry.LastReleaseTime = _timeProvider();
+            if (_settings.TtlSeconds <= 0f)
+            {
+                ReleaseEntry(cacheKey, entry);
+            }
+        }
+
+        private void SweepExpired()
+        {
+            if (_settings.TtlSeconds <= 0f)
+            {
+                return;
+            }
+
+            var now = _timeProvider();
+            _reclaimBuffer.Clear();
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.RefCount <= 0 && now - pair.Value.LastReleaseTime >= _settings.TtlSeconds)
+                {
+                    _reclaimBuffer.Add(pair.Key);
+                }
+            }
+
+            foreach (var cacheKey in _reclaimBuffer)
+            {
+                ReleaseEntry(cacheKey, _entries[cacheKey]);
+            }
+        }
+
+        private void EnforceCapacity()
+        {
+            if (_settings.Capacity <= 0 || _entries.Count <= _settings.Capacity)
+            {
+                return;
+            }
+
+            // 未参照エントリを「最後に手放した時刻が古い順」に解放して上限まで詰める。
+            _reclaimBuffer.Clear();
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.RefCount <= 0)
+                {
+                    _reclaimBuffer.Add(pair.Key);
+                }
+            }
+
+            _reclaimBuffer.Sort((left, right) => _entries[left].LastReleaseTime.CompareTo(_entries[right].LastReleaseTime));
+
+            foreach (var cacheKey in _reclaimBuffer)
+            {
+                if (_entries.Count <= _settings.Capacity)
+                {
+                    break;
+                }
+
+                ReleaseEntry(cacheKey, _entries[cacheKey]);
+            }
+        }
+
+        private void ReleaseEntry(CacheKey cacheKey, Entry entry)
+        {
+            _entries.Remove(cacheKey);
+            if (entry.Handle.IsValid())
+            {
+                Addressables.Release(entry.Handle);
+            }
+        }
+
+        private readonly struct CacheKey : IEquatable<CacheKey>
+        {
+            private readonly string _key;
+            private readonly Type _type;
+
+            public CacheKey(string key, Type type)
+            {
+                _key = key;
+                _type = type;
+            }
+
+            public bool Equals(CacheKey other)
+            {
+                return _key == other._key && _type == other._type;
+            }
+
+            public override bool Equals(object obj)
+            {
+                return obj is CacheKey other && Equals(other);
+            }
+
+            public override int GetHashCode()
+            {
+                return HashCode.Combine(_key, _type);
+            }
+        }
+
+        private sealed class Entry
+        {
+            public Entry(AsyncOperationHandle handle)
+            {
+                Handle = handle;
+            }
+
+            public AsyncOperationHandle Handle { get; }
+            public int RefCount { get; set; }
+            public float LastReleaseTime { get; set; }
+        }
+
+        private sealed class AssetReference<T> : IAssetReference<T>
+        {
+            private readonly AssetVaultCache _cache;
+            private readonly CacheKey _cacheKey;
+            private bool _disposed;
+
+            public AssetReference(AssetVaultCache cache, CacheKey cacheKey, T value)
+            {
+                _cache = cache;
+                _cacheKey = cacheKey;
+                Value = value;
+            }
+
+            public T Value { get; }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                {
+                    return;
+                }
+
+                _disposed = true;
+                _cache.ReleaseInternal(_cacheKey);
+            }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultCache.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 209dd8b61c5ee440dbb7f87f11a970ea

--- a/Assets/UniLab/AssetVault/AssetVaultCacheSettings.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheSettings.cs
@@ -1,0 +1,27 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// <see cref="AssetVaultCache"/> の遅延解放ポリシーです。
+    /// </summary>
+    public readonly struct AssetVaultCacheSettings
+    {
+        /// <summary>既定設定（TTL=10秒・上限64件）。</summary>
+        public static AssetVaultCacheSettings Default => new AssetVaultCacheSettings(10f, 64);
+
+        /// <summary>
+        /// 参照カウントが 0 になってからキャッシュに保持する秒数（TTL）。0 以下なら 0 で即解放します。
+        /// </summary>
+        public float TtlSeconds { get; }
+
+        /// <summary>
+        /// キャッシュに保持するエントリ数の上限（LRU）。0 以下なら無制限です。超過時は未参照の古いものから解放します。
+        /// </summary>
+        public int Capacity { get; }
+
+        public AssetVaultCacheSettings(float ttlSeconds, int capacity)
+        {
+            TtlSeconds = ttlSeconds;
+            Capacity = capacity;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultCacheSettings.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheSettings.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 700ad14e3faed4bc09ca4f6dfbfc493f

--- a/Assets/UniLab/AssetVault/AssetVaultServiceExtensions.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultServiceExtensions.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8358c85fdce4247ee97dfa92e12a404e

--- a/Assets/UniLab/AssetVault/Interface/IAssetReference.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetReference.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// キャッシュから取得したアセットへの参照です。Dispose で参照カウントを1つ手放します
+    /// （0 になっても TTL/LRU の猶予で即解放されるとは限りません）。
+    /// </summary>
+    public interface IAssetReference<out T> : IDisposable
+    {
+        /// <summary>解決済みのアセット本体です。</summary>
+        T Value { get; }
+    }
+}

--- a/Assets/UniLab/AssetVault/Interface/IAssetReference.cs.meta
+++ b/Assets/UniLab/AssetVault/Interface/IAssetReference.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e497f181b82c94fb08b835ef564456a7

--- a/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
@@ -1,0 +1,24 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// アセットを参照カウントで共有・キャッシュするための API です。
+    /// 同じ key の Acquire は同一アセットを共有し、参照が 0 になっても TTL（猶予時間）/ LRU（件数上限）に従って遅延解放します。
+    /// オブジェクトプールや「再利用ごとに差し替わるアセット」での再読み込み churn を抑えるために使います。
+    /// </summary>
+    public interface IAssetVaultCache
+    {
+        /// <summary>
+        /// key で asset を取得します（未ロードならロード、既存なら共有して参照カウント+1）。
+        /// 返り値の <see cref="IAssetReference{T}"/> を Dispose すると参照カウントを手放します。
+        /// </summary>
+        UniTask<IAssetReference<T>> AcquireAsync<T>(string key, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// 期限切れ（TTL 超過）・上限超過（LRU）の未参照エントリを今すぐ解放します。任意タイミングで呼べます。
+        /// </summary>
+        void Trim();
+    }
+}

--- a/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs.meta
+++ b/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ba3bd262ae5e54c2b99a3fdd699180c6

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultPoolSample.cs
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultPoolSample.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Sample
+{
+    /// <summary>
+    /// オブジェクトプール × AssetVault のサンプルです。
+    ///   - プレハブ“資産”は LoadAssetAsync&lt;GameObject&gt;(this) でプール寿命に保持（InstantiateAsync は使わない）
+    ///   - インスタンスは自前 Instantiate でプール管理（Get/Return はアクティブ切替のみ＝再ロードしない）
+    ///   - 要素の表示スプライトは AssetSlot で差し替え（溜まらない）＋ 共有キャッシュ（TTL/LRU）で churn 回避
+    ///   - プール破棄時にプレハブ資産・キャッシュ・Service をまとめて解放
+    /// 自己完結のため Service / Cache を直接 new しています（実プロジェクトは DI 注入）。
+    /// </summary>
+    public sealed class AssetVaultPoolSample : MonoBehaviour
+    {
+        [Header("配信先 BaseUrl（Local のみなら空でよい）")]
+        [SerializeField] private string _baseUrl = "";
+
+        [Header("プール対象プレハブのアドレス（PooledIcon + Image を持つプレハブ）")]
+        [SerializeField] private string _itemPrefabAddress = "UI/IconItem";
+
+        [Header("差し替えに使うスプライトのアドレス（順に切り替える）")]
+        [SerializeField] private string[] _spriteAddresses = { "Icons/coin", "Icons/gem" };
+
+        [Header("生成先・初期プールサイズ")]
+        [SerializeField] private Transform _content;
+        [SerializeField] private int _initialPoolSize = 5;
+
+        private readonly AddressablesAssetVaultService _assetVaultService = new();
+        private readonly AssetVaultCache _assetVaultCache = new();
+        private readonly Stack<PooledIcon> _inactiveItems = new();
+
+        private GameObject _itemPrefab;
+
+        private void Start()
+        {
+            RunAsync(destroyCancellationToken).Forget();
+        }
+
+        private async UniTask RunAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _assetVaultService.InitializeAsync(_baseUrl, cancellationToken);
+
+                // プレハブ資産は owner=this(プール) でロード＝プール GameObject 破棄まで解放されない。
+                _itemPrefab = await _assetVaultService.LoadAssetAsync<GameObject>(this, _itemPrefabAddress, cancellationToken);
+
+                for (var index = 0; index < _initialPoolSize; index++)
+                {
+                    _inactiveItems.Push(CreateItem());
+                }
+
+                // デモ: スプライトを切り替えながら Get→表示→Return を繰り返す（再ロードは起きない）。
+                for (var step = 0; step < _spriteAddresses.Length * 2; step++)
+                {
+                    var item = Get();
+                    await item.SetIconAsync(_spriteAddresses[step % _spriteAddresses.Length], cancellationToken);
+                    await UniTask.Delay(TimeSpan.FromSeconds(1), cancellationToken: cancellationToken);
+                    Return(item);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                // 画面破棄による正常キャンセル。
+            }
+            catch (AssetVaultException exception)
+            {
+                Debug.LogError(exception);
+            }
+        }
+
+        private PooledIcon CreateItem()
+        {
+            var instance = Instantiate(_itemPrefab, _content);
+            var item = instance.GetComponent<PooledIcon>();
+            item.Initialize(_assetVaultCache);
+            instance.SetActive(false);
+            return item;
+        }
+
+        private PooledIcon Get()
+        {
+            var item = _inactiveItems.Count > 0 ? _inactiveItems.Pop() : CreateItem();
+            item.gameObject.SetActive(true);
+            return item;
+        }
+
+        private void Return(PooledIcon item)
+        {
+            // 破棄せず非アクティブで戻すだけ。スプライトは保持され、再 Get で再ロードしない。
+            item.gameObject.SetActive(false);
+            _inactiveItems.Push(item);
+        }
+
+        private void OnDestroy()
+        {
+            // プレハブ資産は holder(this) が自動解放。共有スプライトは cache、自前 new した Service を破棄する。
+            _assetVaultCache.Dispose();
+            _assetVaultService.Dispose();
+        }
+    }
+}

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultPoolSample.cs.meta
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultPoolSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fcc8f690eecc9457ca682d13b4a88eec

--- a/Assets/UniLab/Sample/AssetVault/PooledIcon.cs
+++ b/Assets/UniLab/Sample/AssetVault/PooledIcon.cs
@@ -1,0 +1,36 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UniLab.AssetVault.Sample
+{
+    /// <summary>
+    /// プール要素のサンプル。再利用ごとに表示スプライトが変わる前提で、AssetSlot で「1スロット差し替え」管理します。
+    /// auto-holder（service.LoadAssetAsync(this, ...)）だと差し替え分が GameObject 寿命まで溜まるため、動的差し替えは AssetSlot を使う。
+    /// </summary>
+    public sealed class PooledIcon : MonoBehaviour
+    {
+        [SerializeField] private Image _image;
+
+        private AssetSlot<Sprite> _iconSlot;
+
+        /// <summary>プール生成時に1回呼び、共有キャッシュを渡してスロットを用意します（非 DI サンプルのため明示注入）。</summary>
+        public void Initialize(IAssetVaultCache cache)
+        {
+            _iconSlot ??= new AssetSlot<Sprite>(cache);
+        }
+
+        /// <summary>表示スプライトを差し替えます。旧スプライトは解放され、新スプライトを取得します（溜まらない）。</summary>
+        public async UniTask SetIconAsync(string spriteKey, CancellationToken cancellationToken)
+        {
+            _image.sprite = await _iconSlot.SetAsync(spriteKey, cancellationToken);
+        }
+
+        private void OnDestroy()
+        {
+            // プール破棄（この GameObject 破棄）でスロットの現参照を解放する。
+            _iconSlot?.Dispose();
+        }
+    }
+}

--- a/Assets/UniLab/Sample/AssetVault/PooledIcon.cs.meta
+++ b/Assets/UniLab/Sample/AssetVault/PooledIcon.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 873cb0a3dd67d43a1b52f6c010a742a1

--- a/docs/asset-vault-getting-started.md
+++ b/docs/asset-vault-getting-started.md
@@ -57,6 +57,9 @@ builder.Register<IAssetVaultService, AddressablesAssetVaultService>(Lifetime.Sin
 builder.Register(resolver =>
         resolver.Resolve<IAssetVaultService>().CreateScope(),
     Lifetime.Scoped);
+
+// 共有・オブジェクトプール向けキャッシュ（任意。使う場合のみ）
+builder.Register<IAssetVaultCache>(_ => new AssetVaultCache(), Lifetime.Singleton);
 ```
 
 ### 設計方針: DI（VContainer）前提

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -5,11 +5,16 @@ API 仕様の俯瞰は [asset-vault-guide.md](asset-vault-guide.md)、配信設�
 
 ---
 
-## 2 つの使い方（標準 / 上位）
+## 使い方の選択肢
 
 | 方式 | 書き方 | 解放タイミング | 使うとき |
 |---|---|---|---|
-| **標準: service 拡張** | `service.LoadAssetAsync<T>(owner, key)` | **owner の GameObject 破棄で自動** | 単一コンポーネントが自分用の asset を読む大半のケース |
+| **標準: service 拡張** | `service.LoadAssetAsync<T>(owner, key)` | owner の GameObject 破棄で自動 | 単一コンポーネントが自分用の asset を読む大半のケース |
+| **共有/プール: キャッシュ** | `cache.AcquireAsync<T>(key)` → `reference.Dispose()` | 参照0＋TTL/LRU で遅延解放 | 複数所有・再利用で差し替え・churn を避けたい |
+| **スロット** | `slot.SetAsync(key)` | 差し替え時に旧解放／Dispose で解放 | 「1スロットに常に1枚、差し替わる」要素（プール要素の表示物） |
+| **上位: 明示 Scope** | `scope.LoadAssetAsync<T>(key, ct)` | `scope.Dispose()` で一括 | 画面/シーン単位でまとめたい |
+
+> プール連携・共有・動的差し替えは下の「キャッシュ / スロット」を参照。単発の View ロードは「標準」で十分。
 | **上位: 明示 Scope** | `scope.LoadAssetAsync<T>(key, ct)` | `scope.Dispose()`（画面/シーン単位で一括） | 複数 View をまたいでまとめたい・共有寿命を制御したい |
 
 迷ったら**標準（service 拡張）**。Scope も Dispose も書かずに済む。
@@ -240,6 +245,69 @@ if (size > 0)
 }
 // 以降のロードはキャッシュから即時
 ```
+
+---
+
+## 7. 共有・オブジェクトプール（キャッシュ / スロット）
+
+プールや「再利用ごとに表示が変わる要素」では、スコープの手動 Dispose 管理が辛くなる。`IAssetVaultCache`（参照カウント＋TTL/LRU）と `AssetSlot<T>`（1スロット差し替え）を使う。
+
+### DI 登録
+
+```csharp
+// RootLifetimeScope
+builder.Register<IAssetVaultCache>(_ => new AssetVaultCache(), Lifetime.Singleton);
+// 設定を変えるなら: new AssetVaultCache(new AssetVaultCacheSettings(ttlSeconds: 15f, capacity: 128))
+```
+
+### キャッシュ: Acquire / Release（共有・refcount）
+
+```csharp
+var reference = await _cache.AcquireAsync<Sprite>("Icons/coin", ct); // 参照+1（無ければロード）
+_image.sprite = reference.Value;
+...
+reference.Dispose(); // 参照-1。0 でも TTL 猶予中はキャッシュ保持→再取得は即時、未使用は後で解放
+```
+
+- 同じ key は共有（複数所有しても実体1つ）。
+- 参照0でも **TTL（既定10秒）** の間は保持＝出入りの激しいプールで再ロード（churn）しない。
+- **LRU（既定64件）** で溜め込みすぎを防止。設定は `AssetVaultCacheSettings`。
+
+### スロット: 1枚を差し替える要素（プール要素向け）
+
+```csharp
+public sealed class PooledEnemy : MonoBehaviour
+{
+    [Inject] private readonly IAssetVaultCache _cache;
+    [SerializeField] private Image _image;
+    private AssetSlot<Sprite> _icon;
+
+    private void Awake() => _icon = new AssetSlot<Sprite>(_cache);
+
+    // 再利用のたびに呼ぶだけ。旧解放→新取得を内部で行い、溜まらない。
+    public async UniTask SetupAsync(string spriteKey, CancellationToken ct)
+    {
+        _image.sprite = await _icon.SetAsync(spriteKey, ct);
+    }
+
+    private void OnDestroy() => _icon.Dispose(); // プール破棄時に解放
+}
+```
+
+### プール本体（プレハブ資産はプール寿命で保持）
+
+```csharp
+// プレハブ“資産”は LoadAssetAsync<GameObject>(owner=プール) で1回ロード（InstantiateAsync は使わない）
+_prefab = await _assetVault.LoadAssetAsync<GameObject>(this, key, ct);
+// インスタンスは自前 Instantiate でプール管理。Get/Return はアクティブ切替のみ（再ロードしない）
+// プール GameObject 破棄で _prefab は自動 Release
+```
+
+### 落とし穴
+
+- **動的差し替えの要素に `service.LoadAssetAsync(this, key)`（auto-holder）を使わない**。holder のスコープは GameObject 寿命まで解放されず、差し替えるたびに溜まる（実質リーク）。動的は **スロット or キャッシュ**を使う。
+- プールのインスタンス生成は `InstantiateAsync` ではなく `LoadAssetAsync<GameObject>` ＋ 自前 `Instantiate`。
+- アセットの所有者を1つに決める（プールでプリロード or 要素でスロット、の二重所有を避ける）。
 
 ---
 


### PR DESCRIPTION
## 概要
オブジェクトプールや動的差し替えで「再ロード churn」「アセットの溜まり」を起こさないための共有キャッシュとスロットを追加。

## 主な変更
- **`IAssetVaultCache` / `AssetVaultCache`**: 参照カウント＋TTL（既定10秒）/ LRU（既定64件）で共有・遅延解放。`AcquireAsync<T>(key)` / `reference.Dispose()` / `Trim()`。`AssetVaultCacheSettings`・timeProvider 差し替え可
- **`IAssetReference<T>`**: 取得アセット参照（Dispose で参照-1）
- **`AssetSlot<T>`**: 1スロット差し替え（旧解放→新取得で溜まらない、連続差し替えはキャンセル整合）
- **サンプル**: `AssetVaultPoolSample` / `PooledIcon`（プール×キャッシュ×スロットの実例）
- **整理**: 新規インターフェースを `Interface/` フォルダへ集約（.meta も移動）
- **ドキュメント**: usage / getting-started にキャッシュ・スロット・プール連携・DI 登録を追記

## 確認
- Unity でコンパイル通過済み（`ReleaseInternal` 可視性 CS0051 修正済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)