### PR TITLE
feat: ラベル一括ロード LoadAssetsAsync<T>(label) を追加

### DIFF
--- a/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
@@ -30,6 +30,13 @@ namespace UniLab.AssetVault.Editor.Tests
         }
 
         [Test]
+        public void CreateLabel_フォルダ名をプレフィックスなしで返す()
+        {
+            Assert.AreEqual("Icons", AssetVaultAddressing.CreateLabel("Assets/Local/Icons"));
+            Assert.AreEqual("Characters", AssetVaultAddressing.CreateLabel("Assets/Remote/Characters"));
+        }
+
+        [Test]
         public void NormalizeAssetPath_区切り統一と末尾スラッシュ除去をする()
         {
             Assert.AreEqual("Assets/Foo/Bar", AssetVaultAddressing.NormalizeAssetPath("Assets\\Foo\\Bar/"));

--- a/Assets/UniLab/AssetVault/AssetScope.cs
+++ b/Assets/UniLab/AssetVault/AssetScope.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -29,6 +30,29 @@ namespace UniLab.AssetVault
             catch (Exception exception) when (exception is not OperationCanceledException)
             {
                 throw AssetVaultOperationGuard.ToAssetVaultException(exception, $"Failed to load asset by key '{key}'.");
+            }
+        }
+
+        /// <summary>
+        /// label を付与した asset 群を一括ロードし、その Addressables handle をこの scope の所有にします。
+        /// 型 T が結果のフィルタとして働くため、同一ラベル内に他の型が混在していても問題ありません。
+        /// </summary>
+        public async UniTask<IReadOnlyList<T>> LoadAssetsAsync<T>(string label, CancellationToken cancellationToken)
+        {
+            try
+            {
+                var handle = Addressables.LoadAssetsAsync<T>(label, null);
+                _handles.Add(handle);
+
+                var assets = await handle.ToUniTask(cancellationToken: cancellationToken);
+                AssetVaultOperationGuard.ThrowIfFailed(handle, $"Failed to load assets by label '{label}'.");
+
+                // List<T> は IReadOnlyList<T> を実装するため通常は無アロケーションでキャストできる。
+                return assets as IReadOnlyList<T> ?? assets.ToList();
+            }
+            catch (Exception exception) when (exception is not OperationCanceledException)
+            {
+                throw AssetVaultOperationGuard.ToAssetVaultException(exception, $"Failed to load assets by label '{label}'.");
             }
         }
 

--- a/Assets/UniLab/AssetVault/AssetVaultServiceExtensions.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultServiceExtensions.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -27,6 +28,25 @@ namespace UniLab.AssetVault
         public static UniTask<T> LoadAssetAsync<T>(this IAssetVaultService service, Component owner, string key, CancellationToken cancellationToken = default)
         {
             return service.LoadAssetAsync<T>(owner.gameObject, key, cancellationToken);
+        }
+
+        /// <summary>
+        /// label を付与した asset 群を一括ロードします。ハンドルは owner の GameObject に紐づき、破棄時に自動 Release されます。
+        /// 型 <typeparamref name="T"/> が結果のフィルタとして働くため、同一ラベル内に他の型が混在していても問題ありません。
+        /// cancellationToken 未指定時は owner の GameObject 破棄トークンを使い、ロード中のキャンセルも自動化します。
+        /// </summary>
+        public static UniTask<IReadOnlyList<T>> LoadAssetsAsync<T>(this IAssetVaultService service, GameObject owner, string label, CancellationToken cancellationToken = default)
+        {
+            var holder = AssetScopeHolder.GetOrAttach(owner, service);
+            return holder.Scope.LoadAssetsAsync<T>(label, ResolveToken(holder, cancellationToken));
+        }
+
+        /// <summary>
+        /// <see cref="LoadAssetsAsync{T}(IAssetVaultService,GameObject,string,CancellationToken)"/> の Component 版です。
+        /// </summary>
+        public static UniTask<IReadOnlyList<T>> LoadAssetsAsync<T>(this IAssetVaultService service, Component owner, string label, CancellationToken cancellationToken = default)
+        {
+            return service.LoadAssetsAsync<T>(owner.gameObject, label, cancellationToken);
         }
 
         /// <summary>

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
@@ -42,6 +42,16 @@ namespace UniLab.AssetVault.Editor
         }
 
         /// <summary>
+        /// フォルダ名から一括ロード用ラベル（= フォルダ名そのもの）を作ります。
+        /// ラベルは「まとめてロードする単位」を表し、LoadAssetsAsync&lt;T&gt;(label) で横断取得します。
+        /// Local/Remote のプレフィックスは付けません（ロードは配信先を区別しない source-agnostic 方針のため）。
+        /// </summary>
+        public static string CreateLabel(string folderPath)
+        {
+            return Path.GetFileName(folderPath);
+        }
+
+        /// <summary>
         /// アセットパスの区切りを "/" に統一し、末尾スラッシュを除去します。null/空は空文字を返します。
         /// </summary>
         public static string NormalizeAssetPath(string assetPath)

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -260,7 +260,8 @@ namespace UniLab.AssetVault.Editor
             {
                 var groupName = AssetVaultAddressing.GetGroupName(subFolder, isLocal);
                 var group = EnsureGroup(settings, groupName, isLocal);
-                RegisterFolder(settings, group, subFolder, categoryRoot, duplicateAddressCollector, registeredGuids);
+                var label = AssetVaultAddressing.CreateLabel(subFolder);
+                RegisterFolder(settings, group, subFolder, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
 
             RegisterDirectAssets(settings, categoryRoot, isLocal, duplicateAddressCollector, registeredGuids);
@@ -293,13 +294,14 @@ namespace UniLab.AssetVault.Editor
             AddressableAssetGroup group,
             string folder,
             string categoryRoot,
+            string label,
             AssetVaultDuplicateAddressCollector duplicateAddressCollector,
             HashSet<string> registeredGuids)
         {
             var guids = AssetDatabase.FindAssets(string.Empty, new[] { folder });
             foreach (var guid in guids)
             {
-                RegisterAsset(settings, group, guid, categoryRoot, duplicateAddressCollector, registeredGuids);
+                RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
         }
 
@@ -311,6 +313,8 @@ namespace UniLab.AssetVault.Editor
             HashSet<string> registeredGuids)
         {
             var group = default(AddressableAssetGroup);
+            // ルートフォルダ直下アセットの一括ロード用ラベルは、ルートフォルダ名から作る。
+            var label = AssetVaultAddressing.CreateLabel(categoryRoot);
             var guids = AssetDatabase.FindAssets(string.Empty, new[] { categoryRoot });
             foreach (var guid in guids)
             {
@@ -332,7 +336,7 @@ namespace UniLab.AssetVault.Editor
                     group = EnsureGroup(settings, AssetVaultAddressing.GetGroupName(categoryRoot, isLocal), isLocal);
                 }
 
-                RegisterAsset(settings, group, guid, categoryRoot, duplicateAddressCollector, registeredGuids);
+                RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
         }
 
@@ -341,6 +345,7 @@ namespace UniLab.AssetVault.Editor
             AddressableAssetGroup group,
             string guid,
             string categoryRoot,
+            string label,
             AssetVaultDuplicateAddressCollector duplicateAddressCollector,
             HashSet<string> registeredGuids)
         {
@@ -357,6 +362,9 @@ namespace UniLab.AssetVault.Editor
             }
 
             entry.address = AssetVaultAddressing.CreateAddress(assetPath, categoryRoot);
+            // フォルダ単位の一括ロード（LoadAssetsAsync<T>(label)）用にラベルを付与する。
+            // force:true で settings 未登録のラベルは自動登録し、postEvent:false でバッチ中の再評価を抑える。
+            entry.SetLabel(label, true, true, false);
             registeredGuids.Add(guid);
             duplicateAddressCollector.Record(entry.address, assetPath);
         }

--- a/Assets/UniLab/AssetVault/Interface/IAssetScope.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetScope.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
@@ -14,6 +15,12 @@ namespace UniLab.AssetVault
         /// 所有元の画面または scene 向けに key で asset をロードし、scope が破棄されるまで handle を追跡します。
         /// </summary>
         UniTask<T> LoadAssetAsync<T>(string key, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// label を付与した asset 群を一括ロードし、scope が破棄されるまで handle を追跡します。
+        /// 型 <typeparamref name="T"/> が結果のフィルタとして働くため、同一ラベル内に他の型が混在していても問題ありません。
+        /// </summary>
+        UniTask<IReadOnlyList<T>> LoadAssetsAsync<T>(string label, CancellationToken cancellationToken);
 
         /// <summary>
         /// 指定された parent 配下に key で GameObject を生成し、scope が破棄されるまで handle を追跡します。

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -55,6 +55,20 @@ public sealed class IconView : MonoBehaviour
 - `_assetVault.InstantiateAsync(this, key, parent)` も同様（生成物も GameObject 破棄で解放）。
 - 前提: 別途 `IAssetVaultService.InitializeAsync` 済みであること（起動シーケンス）。
 
+### ラベル一括ロード: `LoadAssetsAsync<T>(label)`
+
+「まとめてロードしたい単位」を **ラベル**で一括取得する。ラベルは **Sync 時にサブフォルダ名から自動付与**される（規約：1サブフォルダ ＝ 1ラベル）。手動でラベルを振る必要はない。
+
+```csharp
+// Local/Icons/ 配下を一括ロード。owner(this) の GameObject 破棄で自動 Release。
+IReadOnlyList<Sprite> icons = await _assetVault.LoadAssetsAsync<Sprite>(this, "Icons");
+```
+
+- **型 `T` がフィルタ**として働く。`Icons/` に Sprite と Prefab が混在していても `LoadAssetsAsync<Sprite>("Icons")` は Sprite だけ返す（混在はエラーにならない）。全部欲しければ `LoadAssetsAsync<UnityEngine.Object>("Icons")`。
+- ラベルは **Local/Remote を区別しない**（source-agnostic）。同名フォルダが両方にあれば両方から読む。Remote の事前 DL が要るかは `GetDownloadSizeAsync` / `DownloadAsync` で判断する（label をそのまま渡せる）。
+- 明示 Scope 版は `scope.LoadAssetsAsync<T>(label, ct)`。
+- **規約の指針**: ラベルは「型」ではなく「**ロード単位（用途）**」で切る（例 `HomeIcon` / `BattleIcon`）。型分割（`Icons/Sprite`, `Icons/Prefab`）は `T` が捌くので不要。
+
 > 以降は **上位: 明示 Scope** 方式の説明。共有寿命や画面単位の一括解放が要るときに使う。
 
 ## 明示 Scope の原則（最初に押さえる3点）
@@ -80,6 +94,9 @@ public interface IAssetScope : IDisposable
 {
     // key で asset をロード（Sprite / ScriptableObject / GameObject(プレハブ資産) 等）
     UniTask<T> LoadAssetAsync<T>(string key, CancellationToken cancellationToken);
+
+    // label を付与した asset 群を一括ロード（T が型フィルタとして働く）
+    UniTask<IReadOnlyList<T>> LoadAssetsAsync<T>(string label, CancellationToken cancellationToken);
 
     // key の GameObject を parent 配下に生成（インスタンス化まで行う）
     UniTask<GameObject> InstantiateAsync(string key, Transform parent, CancellationToken cancellationToken);


### PR DESCRIPTION
## 概要
フォルダ規約に乗せて Addressables のラベルを Sync 時に自動付与し、`LoadAssetsAsync<T>(label)` で一括ロードできるようにした。

## 主な変更
- `AssetVaultAddressing.CreateLabel`（ラベル＝サブフォルダ名、Local/Remote プレフィックスなしの source-agnostic）
- Sync 時に `entry.SetLabel` でラベル自動付与
- `IAssetScope.LoadAssetsAsync<T>(label)` ＋ `AssetScope` 実装（handle を scope 所有）
- owner 連動の拡張メソッド（GameObject/Component 版）
- `AssetVaultAddressingTest` に `CreateLabel` テスト追加
- usage ドキュメント更新

## 設計
型 T が結果のフィルタとして働くため1ラベル内に型混在可。

🤖 Generated with [Claude Code](https://claude.com/claude-code)