### PR TITLE
docs: ラベル一括ロード実装の devlog を追記

### DIFF
--- a/docs/devlog/2026-06-15-asset-vault-overhaul.md
+++ b/docs/devlog/2026-06-15-asset-vault-overhaul.md
@@ -1,0 +1,62 @@
+# 作業ログ 2026-06-15（AssetVault Editor 再編〜ロード API/キャッシュ整備）
+
+作業時間帯: 2026-06-14 20:46 〜 2026-06-15 02:20（コミット span ≈ 約5.5時間）
+ブランチ: develop（PR #8〜#13 をマージ）
+
+## 今日やったこと（PR 単位）
+
+- **#8 Editor 再編**: 統合ダッシュボード `UniLab > AssetVault > Dashboard`（Setup/Build/Debug Override/Status）＋操作レイヤ `AssetVaultEditorOperations` に分離。レビュー指摘 R1〜R4 修正。Sample 削除、`AssetVaultProfileSwitcher` 廃止。
+- **同期方式の確定**: フォルダ規約固定 → **Local/Remote 2スロット方式**（`AssetVaultSetupSettings` に DefaultAsset フォルダ参照2つ。Local 必須・Remote 任意）。Sync は設定 Inspector の1か所に集約（Dashboard・MenuItem からは排除）。用語を Internal/External → Local/Remote に統一。
+- **#8 後半 堅牢化**: stale エントリ/空グループのプルーニング、重複アドレスは失敗扱い、純粋ロジック（`AssetVaultAddressing`/`AssetVaultDuplicateAddressCollector`）抽出＋EditMode テスト。
+- **Debug Override**: dev ビルド対応（専用 asmdef `UniLab.AssetVault.Debug`、`UNITY_EDITOR || DEVELOPMENT_BUILD` で release はコード・アセットとも除外）。**BaseUrl のみ上書き**（版は version.json 解決に委譲）。有効化/選択は**コード/メニュー経由**（`Activate`/`Deactivate`、`Select Environment...`）。
+- **#9 高/中改善**: Debug 適用責務分離、Play 中の永続化抑止、ビルド API 例外処理、入力検証、未選択フォールバック撤廃、`GetStatus` の副作用排除（TryLoad）、Content Update ボタンの事前条件反映 ほか。
+- **#10/#11 ロード API**: `InitializeAsync(baseUrl, ct)` 化（初期化前に BaseUrl 確定→version.json で版解決→Override 優先）。破棄連動ロードを **`IAssetVaultService` 拡張 `LoadAssetAsync(owner, key)`**（GameObject/Component 両対応、`AssetScopeHolder` が破棄で自動 Release）に集約。`AssetVaultManager`/`this.LoadAssetAsync` 拡張は廃止。**DI(VContainer)前提**を明文化（SingletonMonoBehaviour 不採用）。
+- **#12 キャッシュ/スロット**: `IAssetVaultCache`/`AssetVaultCache`（参照カウント＋TTL/LRU）、`AssetSlot<T>`（1スロット差し替え）、プールサンプル（`AssetVaultPoolSample`/`PooledIcon`）。新規 IF を `Interface/` へ集約。
+- **#13 source-agnostic**: 「ロードは Local/Remote を区別しない（行き先はアドレス＝グループで確定）」を usage に明記。`LocalAssetSample` 追加。Load API は1本のまま（分割しない方針）。
+- enum 既定値 `None`／target-typed `new()` を C# 規約として採用（メモリにも保存）。
+
+## 設計判断の経緯（要点）
+
+- 同期は「プロジェクトごとにフォルダが違う」→一度ルールリスト案→最終的に **Local/Remote 固定2スロット**（Local 必須/Remote 任意）に収束。配信先は**スロットで決定**しフォルダ名に依存しない。
+- ロード API は **source-agnostic**。Local/Remote で分けない（行き先はアドレスで確定、メソッド名では変えられず誤解を生むため）。通信要否は `GetDownloadSizeAsync` で判定。
+- 寿命管理は3レイヤー: **(1) service 拡張（owner=GameObject 破棄連動）/(2) 明示 Scope（画面一括）/(3) Cache+Slot（共有・プール・動的差し替え）**。
+- Debug 用アセット/コードは release から完全除外（define 制約＋ビルド時のみ Resources 複製）。
+
+## 未解決・次にやること
+
+- `docs/task-asset-vault-improvements.md` の 🟢低タスク群（Undo 記録、`AddressableSettingsAccessor` 注入での Sync 統合テスト、BuildProcessor の一時 Resources 掃除、`Debug.asmdef` の autoReferenced、ログ英日統一 等）。
+- 追加機能候補（優先順）: ~~ラベル一括ロード `LoadAssetsAsync<T>(label)`~~（**完了: PR #14。下記追記参照**）→ **キャッシュ Prewarm** → **診断 API（ロード中ハンドル数/キャッシュ統計）**。他: Addressables シーンロード、リトライ方針、低メモリ時自動 Trim、署名付き URL フック。
+- Unity 実機での通し確認（特に Debug Override の dev ビルド・cache の TTL/LRU 挙動）。
+
+## メモ
+
+- git/gh はメインで直接実行（git-runner が応答不調だったため）。
+- ツール呼び出しの `antml:` プレフィックス付け忘れで空振りが多発 → 以後注意。
+
+---
+
+## 追記 2026-06-16: ラベル一括ロード `LoadAssetsAsync<T>(label)`（PR #14）
+
+機能候補の筆頭だった**ラベル一括ロード**を実装し、develop へマージ済み（PR #14）。
+
+### やったこと
+- **ラベル＝サブフォルダ名**を Sync 時に自動付与。`AssetVaultAddressing.CreateLabel(folderPath)`（純粋関数、Local/Remote プレフィックスなし）＋ `RegisterAsset` で `entry.SetLabel(label, true, true, false)`（force で settings 未登録ラベルを自動登録、postEvent:false でバッチ中の再評価抑制）。
+- **`IAssetScope.LoadAssetsAsync<T>(label)`** ＋ `AssetScope` 実装。handle を scope 所有にして Dispose で一括 Release。戻り値は `IReadOnlyList<T>`（`IList<T>`→`as IReadOnlyList<T> ?? ToList()` で通常は無アロケ）。
+- **owner 連動の拡張メソッド**（GameObject/Component 版）を `AssetVaultServiceExtensions` に追加。既存 `AssetScopeHolder` 経路を再利用。
+- `AssetVaultAddressingTest` に `CreateLabel` テスト追加。usage ドキュメント更新。
+
+### 設計判断
+- ラベルは **source-agnostic**（Local/Remote を区別しない）。同名フォルダが両方にあれば両方から読む。
+- **型 `T` が結果フィルタ**として働くため、1ラベル内に型混在 OK（依存アセットは暗黙依存で同梱、エントリ化は必須でない）。
+- 規約は「**1サブフォルダ ＝ 1ロード単位（ラベル）**」。ラベルは型ではなく**用途**で切る（例 `HomeIcon`/`BattleIcon`）。型分割（`Icons/Sprite`, `Icons/Prefab`）は T が捌くので不要。
+
+### 見送り（MVP 対象外）
+- 依存アセットの登録スキップ規約（`_` 始まりフォルダ）・共有依存のグループ化（重複バンドル対策）→ 実機ビルドで Addressables Analyze に重複が出てから増分対応。
+- orphan ラベル文字列の掃除（無害なため放置）。
+
+### 動作確認
+- Unity 実機で `UniLab > AssetVault > Dashboard`（設定 Inspector）から Sync → Addressables Groups ウィンドウでフォルダ名ラベルが各エントリに付与されることを確認済み。
+
+### 次にやること
+- **キャッシュ Prewarm** → **診断 API**（優先順は据え置き）。
+- 今回 git/gh は git-runner（haiku）に委譲して実行（前回の不調から復帰）。


### PR DESCRIPTION
PR #14 のラベル一括ロード実装内容・設計判断・次にやること（Prewarm→診断API）を devlog に追記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)