### PR TITLE
feat: AssetVault の Group アセット自動登録（インクリメンタル）

### DIFF
--- a/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
@@ -44,6 +44,36 @@ namespace UniLab.AssetVault.Editor.Tests
         }
 
         [Test]
+        public void IsUnderRoot_一致と配下だけをtrueにする()
+        {
+            Assert.IsTrue(AssetVaultAddressing.IsUnderRoot("Assets/Local", "Assets/Local"));
+            Assert.IsTrue(AssetVaultAddressing.IsUnderRoot("Assets/Local/Icon.png", "Assets/Local"));
+            Assert.IsFalse(AssetVaultAddressing.IsUnderRoot("Assets/Remote/Icon.png", "Assets/Local"));
+            Assert.IsFalse(AssetVaultAddressing.IsUnderRoot("Assets/LocalStuff/Icon.png", "Assets/Local"));
+        }
+
+        [Test]
+        public void ResolveCategoryFolder_ルート直下はルート自身を返す()
+        {
+            var categoryFolder = AssetVaultAddressing.ResolveCategoryFolder("Assets/Local/Icon.png", "Assets/Local");
+            Assert.AreEqual("Assets/Local", categoryFolder);
+        }
+
+        [Test]
+        public void ResolveCategoryFolder_サブフォルダ直下は第一階層を返す()
+        {
+            var categoryFolder = AssetVaultAddressing.ResolveCategoryFolder("Assets/Local/Icons/Icon.png", "Assets/Local");
+            Assert.AreEqual("Assets/Local/Icons", categoryFolder);
+        }
+
+        [Test]
+        public void ResolveCategoryFolder_深いネストも第一階層を返す()
+        {
+            var categoryFolder = AssetVaultAddressing.ResolveCategoryFolder("Assets/Local/Icons/Sub/Icon.png", "Assets/Local");
+            Assert.AreEqual("Assets/Local/Icons", categoryFolder);
+        }
+
+        [Test]
         public void IsManagedGroupName_LocalRemoteプレフィックスのみ管理対象と判定する()
         {
             Assert.IsTrue(AssetVaultAddressing.IsManagedGroupName("Local_Foo"));

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
@@ -65,6 +65,40 @@ namespace UniLab.AssetVault.Editor
         }
 
         /// <summary>
+        /// assetPath が root 直下または配下にあるかを、フォルダ境界を守って判定します。
+        /// </summary>
+        public static bool IsUnderRoot(string assetPath, string root)
+        {
+            var normalizedAssetPath = NormalizeAssetPath(assetPath);
+            var normalizedRoot = NormalizeAssetPath(root);
+            if (string.IsNullOrEmpty(normalizedAssetPath) || string.IsNullOrEmpty(normalizedRoot))
+            {
+                return false;
+            }
+
+            return normalizedAssetPath == normalizedRoot
+                || normalizedAssetPath.StartsWith(normalizedRoot + "/", StringComparison.Ordinal);
+        }
+
+        /// <summary>
+        /// assetPath が属するカテゴリフォルダを返します。グループ名とラベルを手動 Sync と同じ規則で決めるために使います。
+        /// </summary>
+        public static string ResolveCategoryFolder(string assetPath, string categoryRoot)
+        {
+            var normalizedAssetPath = NormalizeAssetPath(assetPath);
+            var normalizedCategoryRoot = NormalizeAssetPath(categoryRoot);
+            var relativePath = normalizedAssetPath.Substring(normalizedCategoryRoot.Length).TrimStart('/');
+            var separatorIndex = relativePath.IndexOf("/", StringComparison.Ordinal);
+            if (separatorIndex < 0)
+            {
+                return normalizedCategoryRoot;
+            }
+
+            var firstFolderName = relativePath.Substring(0, separatorIndex);
+            return normalizedCategoryRoot + "/" + firstFolderName;
+        }
+
+        /// <summary>
         /// AssetVault が同期で生成・管理するグループ名（Local_/Remote_ プレフィックス）かどうかを序数比較で判定します。
         /// </summary>
         public static bool IsManagedGroupName(string groupName)

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAutoDeleteProcessor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAutoDeleteProcessor.cs
@@ -1,0 +1,103 @@
+using UnityEditor;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// Local/Remote ルート配下の削除前に guid を取得し、Addressables エントリを差分削除します。
+    /// </summary>
+    internal sealed class AssetVaultAutoDeleteProcessor : AssetModificationProcessor
+    {
+        private static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions options)
+        {
+            if (!TryCreateContext(out var context))
+            {
+                return AssetDeleteResult.DidNotDelete;
+            }
+
+            if (!IsUnderManagedRoot(context, assetPath))
+            {
+                return AssetDeleteResult.DidNotDelete;
+            }
+
+            // 削除前に guid を確定させる（削除後はパスから引けないため）。フォルダ削除なら配下アセットをまとめて外す。
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                foreach (var childAssetPath in AssetVaultGroupRegistrar.EnumerateFolderAssetPaths(assetPath))
+                {
+                    var childGuid = AssetDatabase.AssetPathToGUID(childAssetPath);
+                    AssetVaultGroupRegistrar.RemoveEntry(context.AddressableAssetSettings, childGuid);
+                }
+
+                return AssetDeleteResult.DidNotDelete;
+            }
+
+            var guid = AssetDatabase.AssetPathToGUID(assetPath);
+            AssetVaultGroupRegistrar.RemoveEntry(context.AddressableAssetSettings, guid);
+            return AssetDeleteResult.DidNotDelete;
+        }
+
+        private static bool TryCreateContext(out DeleteProcessorContext context)
+        {
+            context = default;
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                return false;
+            }
+
+            if (!AssetVaultSetupSettings.TryLoad(out var setupSettings))
+            {
+                return false;
+            }
+
+            if (!setupSettings.AutoRegisterOnAssetChange)
+            {
+                return false;
+            }
+
+            if (!AddressableSettingsAccessor.TryGetSettingsSilently(out var addressableAssetSettings))
+            {
+                return false;
+            }
+
+            var localFolderPath = setupSettings.LocalFolderPath;
+            if (string.IsNullOrEmpty(localFolderPath))
+            {
+                return false;
+            }
+
+            context = new DeleteProcessorContext(
+                addressableAssetSettings,
+                localFolderPath,
+                setupSettings.RemoteFolderPath);
+            return true;
+        }
+
+        private static bool IsUnderManagedRoot(DeleteProcessorContext context, string assetPath)
+        {
+            var normalizedAssetPath = AssetVaultAddressing.NormalizeAssetPath(assetPath);
+            if (AssetVaultAddressing.IsUnderRoot(normalizedAssetPath, context.LocalFolderPath))
+            {
+                return true;
+            }
+
+            return AssetVaultAddressing.IsUnderRoot(normalizedAssetPath, context.RemoteFolderPath);
+        }
+
+        private readonly struct DeleteProcessorContext
+        {
+            public DeleteProcessorContext(
+                UnityEditor.AddressableAssets.Settings.AddressableAssetSettings addressableAssetSettings,
+                string localFolderPath,
+                string remoteFolderPath)
+            {
+                AddressableAssetSettings = addressableAssetSettings;
+                LocalFolderPath = AssetVaultAddressing.NormalizeAssetPath(localFolderPath);
+                RemoteFolderPath = AssetVaultAddressing.NormalizeAssetPath(remoteFolderPath);
+            }
+
+            public UnityEditor.AddressableAssets.Settings.AddressableAssetSettings AddressableAssetSettings { get; }
+            public string LocalFolderPath { get; }
+            public string RemoteFolderPath { get; }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAutoDeleteProcessor.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAutoDeleteProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 92021e602a514e6a9233de8bca9c76a5

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAutoRegisterProcessor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAutoRegisterProcessor.cs
@@ -1,0 +1,265 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.AddressableAssets.Settings;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// Local/Remote ルート配下のインポートと移動を検知し、Addressables 登録を差分更新します。
+    /// </summary>
+    internal sealed class AssetVaultAutoRegisterProcessor : AssetPostprocessor
+    {
+        private static void OnPostprocessAllAssets(
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            if (!TryCreateContext(out var context))
+            {
+                return;
+            }
+
+            var hasRelevantChanges = HasRelevantChanges(context, importedAssets, deletedAssets, movedAssets, movedFromAssetPaths);
+            if (!hasRelevantChanges)
+            {
+                return;
+            }
+
+            var hasRegistrationChanges = HasRegistrationChanges(context, importedAssets, movedAssets);
+            if (hasRegistrationChanges)
+            {
+                AssetVaultGroupRegistrar.EnsureProfileValues(context.AddressableAssetSettings);
+            }
+
+            // バッチ内で同一グループの EnsureGroup（スキーマ再設定）が繰り返されるのを防ぐためのキャッシュ。
+            var groupCache = new Dictionary<string, AddressableAssetGroup>();
+            AssetDatabase.StartAssetEditing();
+            try
+            {
+                RegisterImportedAssets(context, importedAssets, groupCache);
+                RegisterMovedAssets(context, movedAssets, movedFromAssetPaths, groupCache);
+                AssetVaultGroupRegistrar.PruneEmptyManagedGroups(context.AddressableAssetSettings);
+            }
+            finally
+            {
+                AssetDatabase.StopAssetEditing();
+            }
+
+            EditorUtility.SetDirty(context.AddressableAssetSettings);
+            AssetDatabase.SaveAssets();
+        }
+
+        private static bool TryCreateContext(out ProcessorContext context)
+        {
+            context = default;
+            if (EditorApplication.isPlayingOrWillChangePlaymode)
+            {
+                return false;
+            }
+
+            if (!AssetVaultSetupSettings.TryLoad(out var setupSettings))
+            {
+                return false;
+            }
+
+            if (!setupSettings.AutoRegisterOnAssetChange)
+            {
+                return false;
+            }
+
+            if (!AddressableSettingsAccessor.TryGetSettingsSilently(out var addressableAssetSettings))
+            {
+                return false;
+            }
+
+            var localFolderPath = setupSettings.LocalFolderPath;
+            if (string.IsNullOrEmpty(localFolderPath))
+            {
+                return false;
+            }
+
+            context = new ProcessorContext(
+                addressableAssetSettings,
+                localFolderPath,
+                setupSettings.RemoteFolderPath);
+            return true;
+        }
+
+        private static bool HasRelevantChanges(
+            ProcessorContext context,
+            string[] importedAssets,
+            string[] deletedAssets,
+            string[] movedAssets,
+            string[] movedFromAssetPaths)
+        {
+            foreach (var importedAsset in importedAssets)
+            {
+                if (TryResolveManagedRoot(context, importedAsset, out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var deletedAsset in deletedAssets)
+            {
+                if (TryResolveManagedRoot(context, deletedAsset, out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            for (var index = 0; index < movedAssets.Length; index++)
+            {
+                if (TryResolveManagedRoot(context, movedAssets[index], out _, out _))
+                {
+                    return true;
+                }
+
+                if (index < movedFromAssetPaths.Length && TryResolveManagedRoot(context, movedFromAssetPaths[index], out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool HasRegistrationChanges(ProcessorContext context, string[] importedAssets, string[] movedAssets)
+        {
+            foreach (var importedAsset in importedAssets)
+            {
+                if (TryResolveManagedRoot(context, importedAsset, out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            foreach (var movedAsset in movedAssets)
+            {
+                if (TryResolveManagedRoot(context, movedAsset, out _, out _))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void RegisterImportedAssets(ProcessorContext context, string[] importedAssets, IDictionary<string, AddressableAssetGroup> groupCache)
+        {
+            foreach (var importedAsset in importedAssets)
+            {
+                if (!TryResolveManagedRoot(context, importedAsset, out var categoryRoot, out var isLocal))
+                {
+                    continue;
+                }
+
+                RegisterPathOrFolder(context, importedAsset, categoryRoot, isLocal, groupCache);
+            }
+        }
+
+        private static void RegisterMovedAssets(
+            ProcessorContext context,
+            string[] movedAssets,
+            string[] movedFromAssetPaths,
+            IDictionary<string, AddressableAssetGroup> groupCache)
+        {
+            for (var index = 0; index < movedAssets.Length; index++)
+            {
+                var movedAsset = movedAssets[index];
+                if (TryResolveManagedRoot(context, movedAsset, out var categoryRoot, out var isLocal))
+                {
+                    RegisterPathOrFolder(context, movedAsset, categoryRoot, isLocal, groupCache);
+                    continue;
+                }
+
+                if (index >= movedFromAssetPaths.Length)
+                {
+                    continue;
+                }
+
+                if (!TryResolveManagedRoot(context, movedFromAssetPaths[index], out _, out _))
+                {
+                    continue;
+                }
+
+                // ルート外へ出たので登録解除する。フォルダ移動なら配下アセットをまとめて外す。
+                RemovePathOrFolder(context, movedAsset);
+            }
+        }
+
+        // assetPath がフォルダなら配下の全アセットを、ファイルなら自身を登録する（フォルダのリネーム/移動でも子の所属・アドレス・ラベルを追従させる）。
+        private static void RegisterPathOrFolder(ProcessorContext context, string assetPath, string categoryRoot, bool isLocal, IDictionary<string, AddressableAssetGroup> groupCache)
+        {
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                foreach (var childAssetPath in AssetVaultGroupRegistrar.EnumerateFolderAssetPaths(assetPath))
+                {
+                    AssetVaultGroupRegistrar.RegisterSingle(context.AddressableAssetSettings, childAssetPath, categoryRoot, isLocal, groupCache);
+                }
+
+                return;
+            }
+
+            AssetVaultGroupRegistrar.RegisterSingle(context.AddressableAssetSettings, assetPath, categoryRoot, isLocal, groupCache);
+        }
+
+        // assetPath がフォルダなら配下の全アセットのエントリを、ファイルなら自身のエントリを除去する。
+        private static void RemovePathOrFolder(ProcessorContext context, string assetPath)
+        {
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                foreach (var childAssetPath in AssetVaultGroupRegistrar.EnumerateFolderAssetPaths(assetPath))
+                {
+                    var childGuid = AssetDatabase.AssetPathToGUID(childAssetPath);
+                    AssetVaultGroupRegistrar.RemoveEntry(context.AddressableAssetSettings, childGuid);
+                }
+
+                return;
+            }
+
+            var guid = AssetDatabase.AssetPathToGUID(assetPath);
+            AssetVaultGroupRegistrar.RemoveEntry(context.AddressableAssetSettings, guid);
+        }
+
+        private static bool TryResolveManagedRoot(ProcessorContext context, string assetPath, out string categoryRoot, out bool isLocal)
+        {
+            var normalizedAssetPath = AssetVaultAddressing.NormalizeAssetPath(assetPath);
+            if (AssetVaultAddressing.IsUnderRoot(normalizedAssetPath, context.LocalFolderPath))
+            {
+                categoryRoot = context.LocalFolderPath;
+                isLocal = true;
+                return true;
+            }
+
+            if (AssetVaultAddressing.IsUnderRoot(normalizedAssetPath, context.RemoteFolderPath))
+            {
+                categoryRoot = context.RemoteFolderPath;
+                isLocal = false;
+                return true;
+            }
+
+            categoryRoot = string.Empty;
+            isLocal = false;
+            return false;
+        }
+
+        private readonly struct ProcessorContext
+        {
+            public ProcessorContext(
+                UnityEditor.AddressableAssets.Settings.AddressableAssetSettings addressableAssetSettings,
+                string localFolderPath,
+                string remoteFolderPath)
+            {
+                AddressableAssetSettings = addressableAssetSettings;
+                LocalFolderPath = AssetVaultAddressing.NormalizeAssetPath(localFolderPath);
+                RemoteFolderPath = AssetVaultAddressing.NormalizeAssetPath(remoteFolderPath);
+            }
+
+            public UnityEditor.AddressableAssets.Settings.AddressableAssetSettings AddressableAssetSettings { get; }
+            public string LocalFolderPath { get; }
+            public string RemoteFolderPath { get; }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAutoRegisterProcessor.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAutoRegisterProcessor.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 767ae4606f4f4d52a0df291d7b5144a9

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEditor.AddressableAssets.Build;
 using UnityEditor.AddressableAssets.Settings;
-using UnityEditor.AddressableAssets.Settings.GroupSchemas;
 using UnityEngine;
 
 namespace UniLab.AssetVault.Editor
@@ -15,19 +14,8 @@ namespace UniLab.AssetVault.Editor
     /// </summary>
     public static class AssetVaultEditorOperations
     {
-        private const string LocalBuildPathVariableName = "LocalBuildPath";
-        private const string LocalLoadPathVariableName = "LocalLoadPath";
-        private const string RemoteBuildPathVariableName = "RemoteBuildPath";
-        private const string RemoteLoadPathVariableName = "RemoteLoadPath";
-        private const string LocalBuildPathValue = "[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]";
-        private const string LocalLoadPathValue = "{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]";
-        private const string RemoteBuildPathValue = "ServerData/[BuildTarget]";
-        private const string BuildTargetToken = "[BuildTarget]";
-        private const string BaseUrlPropertyName = "BaseUrl";
-        private const string ContentPathPropertyName = "ContentPath";
         private const string CategorySkippedMessageFormat = "AssetVault setup skipped because folder was not found: {0}";
         private const string LocalFolderMissingMessage = "AssetVault setup aborted: the Local folder is required but not set. Assign it in AssetVaultSetupSettings.";
-        private const string ProfileVariableMissingMessageFormat = "Addressables profile variable '{0}' was not found; group build/load path may be misconfigured.";
         private const string DuplicateAddressFailureMessage = "AssetVault setup failed due to duplicate addresses. Resolve the following collisions and run sync again:\n{0}";
         private const string SyncCompletedMessage = "AssetVault Addressables setup completed.";
         private const string ContentStateMissingMessage = "Addressables content state file was not found. Run a new build before a content update build.";
@@ -152,15 +140,7 @@ namespace UniLab.AssetVault.Editor
                 return false;
             }
 
-            EnsureProfileValue(settings, LocalBuildPathVariableName, LocalBuildPathValue);
-            EnsureProfileValue(settings, LocalLoadPathVariableName, LocalLoadPathValue);
-            EnsureProfileValue(settings, RemoteBuildPathVariableName, RemoteBuildPathValue);
-            EnsureProfileValue(settings, RemoteLoadPathVariableName, CreateRemoteLoadPath());
-
-            // RemoteLoadPath / RemoteBuildPath は AssetVaultRuntime のトークン規約・ServerData 規約に毎回追従させるため、
-            // 既存値があっても上書きする（Local 側は EnsureProfileValue で初回のみ。Remote だけ非対称に上書きするのは意図的）。
-            settings.profileSettings.SetValue(settings.activeProfileId, RemoteLoadPathVariableName, CreateRemoteLoadPath());
-            settings.profileSettings.SetValue(settings.activeProfileId, RemoteBuildPathVariableName, RemoteBuildPathValue);
+            AssetVaultGroupRegistrar.EnsureProfileValues(settings);
 
             var duplicateAddressCollector = new AssetVaultDuplicateAddressCollector();
             var registeredGuids = new HashSet<string>();
@@ -178,7 +158,7 @@ namespace UniLab.AssetVault.Editor
                     SyncCategory(settings, remoteFolderPath, false, duplicateAddressCollector, registeredGuids);
                 }
 
-                PruneStaleEntries(settings, registeredGuids);
+                AssetVaultGroupRegistrar.PruneStaleEntries(settings, registeredGuids);
             }
             finally
             {
@@ -227,7 +207,7 @@ namespace UniLab.AssetVault.Editor
                 return new AssetVaultStatus(false, string.Empty, 0, 0, localFolderPath, remoteFolderPath);
             }
 
-            var remoteLoadPath = settings.profileSettings.GetValueByName(settings.activeProfileId, RemoteLoadPathVariableName);
+            var remoteLoadPath = settings.profileSettings.GetValueByName(settings.activeProfileId, AssetVaultGroupRegistrar.RemoteLoadPathVariableName);
             var localGroupCount = settings.groups.Count(group => group != null && group.Name.StartsWith(AssetVaultAddressing.LocalGroupPrefix, System.StringComparison.Ordinal));
             var remoteGroupCount = settings.groups.Count(group => group != null && group.Name.StartsWith(AssetVaultAddressing.RemoteGroupPrefix, System.StringComparison.Ordinal));
 
@@ -259,34 +239,12 @@ namespace UniLab.AssetVault.Editor
             foreach (var subFolder in subFolders)
             {
                 var groupName = AssetVaultAddressing.GetGroupName(subFolder, isLocal);
-                var group = EnsureGroup(settings, groupName, isLocal);
+                var group = AssetVaultGroupRegistrar.EnsureGroup(settings, groupName, isLocal);
                 var label = AssetVaultAddressing.CreateLabel(subFolder);
                 RegisterFolder(settings, group, subFolder, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
 
             RegisterDirectAssets(settings, categoryRoot, isLocal, duplicateAddressCollector, registeredGuids);
-        }
-
-        private static AddressableAssetGroup EnsureGroup(AddressableAssetSettings settings, string groupName, bool isLocal)
-        {
-            var group = settings.FindGroup(groupName);
-            var created = false;
-            if (group == null)
-            {
-                group = settings.CreateGroup(
-                    groupName,
-                    false,
-                    false,
-                    false,
-                    null,
-                    typeof(BundledAssetGroupSchema),
-                    typeof(ContentUpdateGroupSchema));
-                created = true;
-            }
-
-            ConfigureBundledAssetGroupSchema(settings, group, isLocal, created);
-            ConfigureContentUpdateGroupSchema(group, isLocal);
-            return group;
         }
 
         private static void RegisterFolder(
@@ -301,7 +259,7 @@ namespace UniLab.AssetVault.Editor
             var guids = AssetDatabase.FindAssets(string.Empty, new[] { folder });
             foreach (var guid in guids)
             {
-                RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
+                AssetVaultGroupRegistrar.RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
         }
 
@@ -333,121 +291,11 @@ namespace UniLab.AssetVault.Editor
                 if (group == null)
                 {
                     // ルートフォルダ直下のアセットは、そのフォルダ名から作る既定グループにまとめる。
-                    group = EnsureGroup(settings, AssetVaultAddressing.GetGroupName(categoryRoot, isLocal), isLocal);
+                    group = AssetVaultGroupRegistrar.EnsureGroup(settings, AssetVaultAddressing.GetGroupName(categoryRoot, isLocal), isLocal);
                 }
 
-                RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
+                AssetVaultGroupRegistrar.RegisterAsset(settings, group, guid, categoryRoot, label, duplicateAddressCollector, registeredGuids);
             }
-        }
-
-        private static void RegisterAsset(
-            AddressableAssetSettings settings,
-            AddressableAssetGroup group,
-            string guid,
-            string categoryRoot,
-            string label,
-            AssetVaultDuplicateAddressCollector duplicateAddressCollector,
-            HashSet<string> registeredGuids)
-        {
-            var assetPath = AssetDatabase.GUIDToAssetPath(guid);
-            if (AssetDatabase.IsValidFolder(assetPath))
-            {
-                return;
-            }
-
-            var entry = settings.CreateOrMoveEntry(guid, group);
-            if (entry == null)
-            {
-                return;
-            }
-
-            entry.address = AssetVaultAddressing.CreateAddress(assetPath, categoryRoot);
-            // フォルダ単位の一括ロード（LoadAssetsAsync<T>(label)）用にラベルを付与する。
-            // force:true で settings 未登録のラベルは自動登録し、postEvent:false でバッチ中の再評価を抑える。
-            entry.SetLabel(label, true, true, false);
-            registeredGuids.Add(guid);
-            duplicateAddressCollector.Record(entry.address, assetPath);
-        }
-
-        // 管理グループ（Local_/Remote_）から、今回の同期で登録されなかった古いエントリを除去し、空になったグループを削除する。
-        private static void PruneStaleEntries(AddressableAssetSettings settings, HashSet<string> registeredGuids)
-        {
-            var managedGroups = settings.groups
-                .Where(group => group != null && AssetVaultAddressing.IsManagedGroupName(group.Name))
-                .ToList();
-
-            foreach (var group in managedGroups)
-            {
-                var staleEntries = group.entries
-                    .Where(entry => entry != null && !registeredGuids.Contains(entry.guid))
-                    .ToList();
-                foreach (var staleEntry in staleEntries)
-                {
-                    settings.RemoveAssetEntry(staleEntry.guid, false);
-                }
-
-                if (group.entries.Count == 0)
-                {
-                    settings.RemoveGroup(group);
-                }
-            }
-        }
-
-        private static void ConfigureBundledAssetGroupSchema(AddressableAssetSettings settings, AddressableAssetGroup group, bool isLocal, bool created)
-        {
-            var bundledAssetGroupSchema = group.GetSchema<BundledAssetGroupSchema>();
-            if (bundledAssetGroupSchema == null)
-            {
-                bundledAssetGroupSchema = group.AddSchema<BundledAssetGroupSchema>();
-                created = true;
-            }
-
-            // Build/Load パスは Local/Remote の振り分けに直結するため毎回強制する。
-            var buildPathVariableName = isLocal ? LocalBuildPathVariableName : RemoteBuildPathVariableName;
-            var loadPathVariableName = isLocal ? LocalLoadPathVariableName : RemoteLoadPathVariableName;
-            if (!bundledAssetGroupSchema.BuildPath.SetVariableByName(settings, buildPathVariableName))
-            {
-                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, buildPathVariableName));
-            }
-
-            if (!bundledAssetGroupSchema.LoadPath.SetVariableByName(settings, loadPathVariableName))
-            {
-                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, loadPathVariableName));
-            }
-
-            // BundleNaming は新規グループのみ既定値を設定し、既存グループの手動調整は尊重する。
-            if (created)
-            {
-                bundledAssetGroupSchema.BundleNaming = BundledAssetGroupSchema.BundleNamingStyle.AppendHash;
-            }
-        }
-
-        private static void ConfigureContentUpdateGroupSchema(AddressableAssetGroup group, bool isLocal)
-        {
-            var contentUpdateGroupSchema = group.GetSchema<ContentUpdateGroupSchema>();
-            if (contentUpdateGroupSchema == null)
-            {
-                contentUpdateGroupSchema = group.AddSchema<ContentUpdateGroupSchema>();
-            }
-
-            contentUpdateGroupSchema.StaticContent = isLocal;
-        }
-
-        private static void EnsureProfileValue(AddressableAssetSettings settings, string variableName, string defaultValue)
-        {
-            var variableNames = settings.profileSettings.GetVariableNames();
-            if (variableNames.Contains(variableName))
-            {
-                return;
-            }
-
-            settings.profileSettings.CreateValue(variableName, defaultValue);
-        }
-
-        private static string CreateRemoteLoadPath()
-        {
-            var runtimeTypeName = typeof(AssetVaultRuntime).FullName;
-            return $"{{{runtimeTypeName}.{BaseUrlPropertyName}}}/{{{runtimeTypeName}.{ContentPathPropertyName}}}/{BuildTargetToken}";
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs
@@ -1,0 +1,305 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.AddressableAssets.Settings;
+using UnityEditor.AddressableAssets.Settings.GroupSchemas;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetVault 管理グループへの Addressables 登録処理を、手動 Sync と自動差分処理で共有します。
+    /// </summary>
+    internal static class AssetVaultGroupRegistrar
+    {
+        /// <summary>Local グループの BuildPath に使う Addressables プロファイル変数名です。</summary>
+        internal const string LocalBuildPathVariableName = "LocalBuildPath";
+
+        /// <summary>Local グループの LoadPath に使う Addressables プロファイル変数名です。</summary>
+        internal const string LocalLoadPathVariableName = "LocalLoadPath";
+
+        /// <summary>Remote グループの BuildPath に使う Addressables プロファイル変数名です。</summary>
+        internal const string RemoteBuildPathVariableName = "RemoteBuildPath";
+
+        /// <summary>Remote グループの LoadPath に使う Addressables プロファイル変数名です。</summary>
+        internal const string RemoteLoadPathVariableName = "RemoteLoadPath";
+
+        private const string LocalBuildPathValue = "[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]";
+        private const string LocalLoadPathValue = "{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]";
+        private const string RemoteBuildPathValue = "ServerData/[BuildTarget]";
+        private const string BuildTargetToken = "[BuildTarget]";
+        private const string BaseUrlPropertyName = "BaseUrl";
+        private const string ContentPathPropertyName = "ContentPath";
+        private const string ProfileVariableMissingMessageFormat = "Addressables profile variable '{0}' was not found; group build/load path may be misconfigured.";
+
+        /// <summary>
+        /// AssetVault 管理グループのスキーマが参照する Addressables プロファイル変数を用意します。
+        /// </summary>
+        internal static void EnsureProfileValues(AddressableAssetSettings settings)
+        {
+            EnsureProfileValue(settings, LocalBuildPathVariableName, LocalBuildPathValue);
+            EnsureProfileValue(settings, LocalLoadPathVariableName, LocalLoadPathValue);
+            EnsureProfileValue(settings, RemoteBuildPathVariableName, RemoteBuildPathValue);
+            EnsureProfileValue(settings, RemoteLoadPathVariableName, CreateRemoteLoadPath());
+
+            // Remote は AssetVaultRuntime トークンと ServerData 規約に毎回追従させる必要がある。
+            settings.profileSettings.SetValue(settings.activeProfileId, RemoteLoadPathVariableName, CreateRemoteLoadPath());
+            settings.profileSettings.SetValue(settings.activeProfileId, RemoteBuildPathVariableName, RemoteBuildPathValue);
+        }
+
+        /// <summary>
+        /// 指定名の Addressables グループを取得または作成し、AssetVault の Local/Remote スキーマ設定へ揃えます。
+        /// </summary>
+        internal static AddressableAssetGroup EnsureGroup(AddressableAssetSettings settings, string groupName, bool isLocal)
+        {
+            var group = settings.FindGroup(groupName);
+            var created = false;
+            if (group == null)
+            {
+                group = settings.CreateGroup(
+                    groupName,
+                    false,
+                    false,
+                    false,
+                    null,
+                    typeof(BundledAssetGroupSchema),
+                    typeof(ContentUpdateGroupSchema));
+                created = true;
+            }
+
+            ConfigureBundledAssetGroupSchema(settings, group, isLocal, created);
+            ConfigureContentUpdateGroupSchema(group, isLocal);
+            return group;
+        }
+
+        /// <summary>
+        /// guid のアセットを指定グループへ登録し、手動 Sync と同じアドレス・ラベル規則を適用します。
+        /// </summary>
+        internal static void RegisterAsset(
+            AddressableAssetSettings settings,
+            AddressableAssetGroup group,
+            string guid,
+            string categoryRoot,
+            string label,
+            AssetVaultDuplicateAddressCollector duplicateAddressCollector = null,
+            HashSet<string> registeredGuids = null)
+        {
+            var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                return;
+            }
+
+            var entry = settings.CreateOrMoveEntry(guid, group);
+            if (entry == null)
+            {
+                return;
+            }
+
+            entry.address = AssetVaultAddressing.CreateAddress(assetPath, categoryRoot);
+            // 既存ラベルを一旦すべて外し、カテゴリフォルダ由来のラベル1つだけにする。
+            // 別カテゴリへ移動したとき旧フォルダのラベルが残るのを防ぐ（auto/Sync 共通。ラベルはフォルダ規約で自動付与する設計のため手動ラベルは想定しない）。
+            ClearLabels(entry);
+            // フォルダ単位の一括ロード（LoadAssetsAsync<T>(label)）用にラベルを付与する。
+            // force:true で settings 未登録のラベルは自動登録し、postEvent:false でバッチ中の再評価を抑える。
+            entry.SetLabel(label, true, true, false);
+            registeredGuids?.Add(guid);
+            duplicateAddressCollector?.Record(entry.address, assetPath);
+        }
+
+        /// <summary>
+        /// 単一アセットを現在のパスからカテゴリ解決し、対応する AssetVault 管理グループへ差分登録します。
+        /// </summary>
+        internal static void RegisterSingle(
+            AddressableAssetSettings settings,
+            string assetPath,
+            string categoryRoot,
+            bool isLocal,
+            IDictionary<string, AddressableAssetGroup> groupCache = null)
+        {
+            if (AssetDatabase.IsValidFolder(assetPath))
+            {
+                return;
+            }
+
+            var guid = AssetDatabase.AssetPathToGUID(assetPath);
+            if (string.IsNullOrEmpty(guid))
+            {
+                return;
+            }
+
+            // 自動側では重複アドレスの厳密検出は行わない（全走査は大量インポートで重いため）。衝突検出は手動 Sync の責務。
+            var categoryFolder = AssetVaultAddressing.ResolveCategoryFolder(assetPath, categoryRoot);
+            var groupName = AssetVaultAddressing.GetGroupName(categoryFolder, isLocal);
+            var label = AssetVaultAddressing.CreateLabel(categoryFolder);
+            var group = EnsureGroupCached(settings, groupName, isLocal, groupCache);
+            RegisterAsset(settings, group, guid, categoryRoot, label);
+        }
+
+        /// <summary>
+        /// フォルダ配下の全アセットパスを列挙します（フォルダ自身は除外）。フォルダ移動/削除の差分処理で配下を辿るのに使います。
+        /// </summary>
+        internal static IEnumerable<string> EnumerateFolderAssetPaths(string folderPath)
+        {
+            var guids = AssetDatabase.FindAssets(string.Empty, new[] { folderPath });
+            foreach (var guid in guids)
+            {
+                var assetPath = AssetDatabase.GUIDToAssetPath(guid);
+                if (AssetDatabase.IsValidFolder(assetPath))
+                {
+                    continue;
+                }
+
+                yield return assetPath;
+            }
+        }
+
+        // バッチ内で同一グループへの EnsureGroup（スキーマ再設定）が何度も走るのを防ぐため、解決済みグループをキャッシュする。
+        private static AddressableAssetGroup EnsureGroupCached(
+            AddressableAssetSettings settings,
+            string groupName,
+            bool isLocal,
+            IDictionary<string, AddressableAssetGroup> groupCache)
+        {
+            if (groupCache != null && groupCache.TryGetValue(groupName, out var cachedGroup))
+            {
+                return cachedGroup;
+            }
+
+            var group = EnsureGroup(settings, groupName, isLocal);
+            if (groupCache != null)
+            {
+                groupCache[groupName] = group;
+            }
+
+            return group;
+        }
+
+        /// <summary>
+        /// guid の Addressables エントリを AssetVault 管理対象から除去します。存在しない場合は何もしません。
+        /// </summary>
+        internal static void RemoveEntry(AddressableAssetSettings settings, string guid)
+        {
+            if (string.IsNullOrEmpty(guid))
+            {
+                return;
+            }
+
+            settings.RemoveAssetEntry(guid, false);
+        }
+
+        /// <summary>
+        /// 今回の手動 Sync で登録されなかった古いエントリを管理グループから除去し、空グループを削除します。
+        /// </summary>
+        internal static void PruneStaleEntries(AddressableAssetSettings settings, HashSet<string> registeredGuids)
+        {
+            var managedGroups = settings.groups
+                .Where(group => group != null && AssetVaultAddressing.IsManagedGroupName(group.Name))
+                .ToList();
+
+            foreach (var group in managedGroups)
+            {
+                var staleEntries = group.entries
+                    .Where(entry => entry != null && !registeredGuids.Contains(entry.guid))
+                    .ToList();
+                foreach (var staleEntry in staleEntries)
+                {
+                    settings.RemoveAssetEntry(staleEntry.guid, false);
+                }
+
+                RemoveGroupIfEmpty(settings, group);
+            }
+        }
+
+        /// <summary>
+        /// 空になった AssetVault 管理グループを削除します。
+        /// </summary>
+        internal static void PruneEmptyManagedGroups(AddressableAssetSettings settings)
+        {
+            var managedGroups = settings.groups
+                .Where(group => group != null && AssetVaultAddressing.IsManagedGroupName(group.Name))
+                .ToList();
+
+            foreach (var group in managedGroups)
+            {
+                RemoveGroupIfEmpty(settings, group);
+            }
+        }
+
+        private static void ConfigureBundledAssetGroupSchema(AddressableAssetSettings settings, AddressableAssetGroup group, bool isLocal, bool created)
+        {
+            var bundledAssetGroupSchema = group.GetSchema<BundledAssetGroupSchema>();
+            if (bundledAssetGroupSchema == null)
+            {
+                bundledAssetGroupSchema = group.AddSchema<BundledAssetGroupSchema>();
+                created = true;
+            }
+
+            // Build/Load パスは Local/Remote の振り分けに直結するため毎回強制する。
+            var buildPathVariableName = isLocal ? LocalBuildPathVariableName : RemoteBuildPathVariableName;
+            var loadPathVariableName = isLocal ? LocalLoadPathVariableName : RemoteLoadPathVariableName;
+            if (!bundledAssetGroupSchema.BuildPath.SetVariableByName(settings, buildPathVariableName))
+            {
+                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, buildPathVariableName));
+            }
+
+            if (!bundledAssetGroupSchema.LoadPath.SetVariableByName(settings, loadPathVariableName))
+            {
+                Debug.LogWarning(string.Format(ProfileVariableMissingMessageFormat, loadPathVariableName));
+            }
+
+            // BundleNaming は新規グループのみ既定値を設定し、既存グループの手動調整は尊重する。
+            if (created)
+            {
+                bundledAssetGroupSchema.BundleNaming = BundledAssetGroupSchema.BundleNamingStyle.AppendHash;
+            }
+        }
+
+        private static void ConfigureContentUpdateGroupSchema(AddressableAssetGroup group, bool isLocal)
+        {
+            var contentUpdateGroupSchema = group.GetSchema<ContentUpdateGroupSchema>();
+            if (contentUpdateGroupSchema == null)
+            {
+                contentUpdateGroupSchema = group.AddSchema<ContentUpdateGroupSchema>();
+            }
+
+            contentUpdateGroupSchema.StaticContent = isLocal;
+        }
+
+        private static void EnsureProfileValue(AddressableAssetSettings settings, string variableName, string defaultValue)
+        {
+            var variableNames = settings.profileSettings.GetVariableNames();
+            if (variableNames.Contains(variableName))
+            {
+                return;
+            }
+
+            settings.profileSettings.CreateValue(variableName, defaultValue);
+        }
+
+        private static string CreateRemoteLoadPath()
+        {
+            var runtimeTypeName = typeof(AssetVaultRuntime).FullName;
+            return $"{{{runtimeTypeName}.{BaseUrlPropertyName}}}/{{{runtimeTypeName}.{ContentPathPropertyName}}}/{BuildTargetToken}";
+        }
+
+        // エントリに付いている既存ラベルをすべて外す。force:false（settings からは消さない）・postEvent:false でバッチ中の再評価を抑える。
+        private static void ClearLabels(AddressableAssetEntry entry)
+        {
+            foreach (var existingLabel in entry.labels.ToList())
+            {
+                entry.SetLabel(existingLabel, false, false, false);
+            }
+        }
+
+        private static void RemoveGroupIfEmpty(AddressableAssetSettings settings, AddressableAssetGroup group)
+        {
+            if (group.entries.Count > 0)
+            {
+                return;
+            }
+
+            settings.RemoveGroup(group);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 721cac32d72b46a5bccde6723e72d116

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
@@ -20,6 +20,9 @@ namespace UniLab.AssetVault.Editor
         [Tooltip("CDN(Remote)アセットのルートフォルダ。【任意】未設定可。直下サブフォルダがグループ Remote_<名> になります。")]
         [SerializeField] private DefaultAsset _remoteFolder;
 
+        [Tooltip("オンにすると Local/Remote 配下のアセット追加・移動・削除を検知して Addressables を自動登録/更新します。既定オフ。")]
+        [SerializeField] private bool _autoRegisterOnAssetChange;
+
         /// <summary>
         /// 同梱(Local)ルートフォルダのアセットパスです。未設定・非フォルダの場合は null。必須項目です。
         /// </summary>
@@ -29,6 +32,11 @@ namespace UniLab.AssetVault.Editor
         /// CDN(Remote)ルートフォルダのアセットパスです。未設定・非フォルダの場合は null（任意項目）。
         /// </summary>
         public string RemoteFolderPath => ResolveFolderPath(_remoteFolder);
+
+        /// <summary>
+        /// アセット変更時に自動登録を行うか。既定 false（オプトイン）です。
+        /// </summary>
+        public bool AutoRegisterOnAssetChange => _autoRegisterOnAssetChange;
 
         /// <summary>
         /// 設定アセットを副作用なく読み込みます（存在しなければ false）。読み取り専用 UI から使い、アセットの自動生成を避けます。

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
@@ -23,6 +23,8 @@ namespace UniLab.AssetVault.Editor
         private const string LocalNotFolderMessage = "Local Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
         private const string RemoteNotFolderMessage = "Remote Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
         private const string OverlapMessage = "Local と Remote は別フォルダにしてください（同一・入れ子は二重登録やアドレス衝突を招きます）。";
+        private const string AutoRegisterEnabledMessage = "自動登録が有効です。Local/Remote 配下の追加・移動・削除は Addressables へ差分反映されます。厳密な重複検出や全体掃除が必要な場合は Sync AssetResource を実行してください。";
+        private const string AutoRegisterDisabledMessage = "自動登録はオフです。Local/Remote 配下の変更は、下の Sync AssetResource を実行して反映してください。";
 
         public override void OnInspectorGUI()
         {
@@ -56,6 +58,15 @@ namespace UniLab.AssetVault.Editor
             if (hasOverlap)
             {
                 EditorGUILayout.HelpBox(OverlapMessage, MessageType.Warning);
+            }
+
+            if (settings.AutoRegisterOnAssetChange)
+            {
+                EditorGUILayout.HelpBox(AutoRegisterEnabledMessage, MessageType.Info);
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(AutoRegisterDisabledMessage, MessageType.Info);
             }
 
             EditorGUILayout.Space();

--- a/docs/task-asset-vault-auto-register.md
+++ b/docs/task-asset-vault-auto-register.md
@@ -1,0 +1,173 @@
+# タスク仕様: AssetVault Group アセット自動登録（インクリメンタル）
+
+作成日: 2026-06-16
+対象: `Assets/UniLab/AssetVault/Editor/`
+実装担当: Codex / レビュー: Claude Code
+関連: [asset-vault-usage.md](asset-vault-usage.md) / [task-asset-vault-improvements.md](task-asset-vault-improvements.md)
+
+> 既存の `AssetVaultEditorOperations.SyncAssetResource()`（手動ボタン／MenuItem）は全アセット走査で Addressables を再構成する。
+> 本タスクは「Sync 押し忘れ」を防ぐため、**Local/Remote ルート配下のアセット変更を検知して差分だけ自動登録/更新/削除**する仕組みを追加する。
+> **全 Sync の自動実行ではなく、変更差分のインクリメンタル処理**である点が肝。
+
+---
+
+## ゴール
+
+- Local/Remote ルート配下でアセットを **追加・移動・削除** したとき、Addressables のエントリ（グループ所属・アドレス・ラベル）を自動で追従させる。
+- 既存の手動 Sync（厳密チェック・全体再構成）は**そのまま残す**。自動側は軽量・非ブロッキング。
+- **オプトイン**（既定オフ）。設定でオン/オフできる。
+
+## 規約（既存 Sync と完全一致させること）
+
+エントリの所属・アドレス・ラベルは、現状 `SyncCategory` / `RegisterFolder` / `RegisterDirectAssets` / `RegisterAsset` が決めているルールと**1バイトも違えない**:
+
+- グループ名: ルート直下アセット → `Local_<ルート名>` / `Remote_<ルート名>`。サブフォルダ配下 → `Local_<直下サブフォルダ名>`（深いネストは所属に影響せずアドレスのプレフィックスになるだけ）。
+- アドレス: `AssetVaultAddressing.CreateAddress(assetPath, categoryRoot)`（ルート相対・拡張子なし）。
+- ラベル: `AssetVaultAddressing.CreateLabel(categoryFolder)`（カテゴリフォルダ名。Local/Remote プレフィックスなし）。
+  - ここで **categoryFolder** = ルート直下アセットなら categoryRoot 自身、サブフォルダ配下なら「ルート直下の第一階層サブフォルダ」。
+
+---
+
+## 実装内容
+
+### 1. 純粋ロジック追加（テスト対象）
+`Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs`
+
+```csharp
+/// <summary>
+/// assetPath が root 直下／配下にあるか判定します。root と完全一致、または "root/" で始まる場合に true。
+/// "Assets/Local" に対する "Assets/LocalStuff/x" のような前方一致の誤検出を防ぎます。
+/// </summary>
+public static bool IsUnderRoot(string assetPath, string root)
+
+/// <summary>
+/// assetPath が属する「カテゴリフォルダ」を返します。
+/// ルート直下のアセットは categoryRoot 自身を、サブフォルダ配下のアセットは
+/// 「categoryRoot 直下の第一階層サブフォルダ」を返します（グループ/ラベルの決定に使う）。
+/// 例: ("Assets/Local/Icons/Sub/x.png", "Assets/Local") → "Assets/Local/Icons"
+///     ("Assets/Local/x.png",          "Assets/Local") → "Assets/Local"
+/// </summary>
+public static string ResolveCategoryFolder(string assetPath, string categoryRoot)
+```
+
+- 入力は呼び出し側で `NormalizeAssetPath` 済みを前提（区切り "/"）。内部でも防御的に区切り統一してよい。
+- `IsUnderRoot` は必ず `root + "/"` 前方一致を使う（境界バグ注意）。
+
+### 2. 登録コアの抽出（DRY）
+`Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs`（新規・internal static）
+
+現在 `AssetVaultEditorOperations` の private に埋まっている登録系を、**手動 Sync と自動登録の両方から呼べるよう**切り出す。挙動は変えない。
+
+移設/共用するメソッド（名前は現状踏襲、シグネチャは下記）:
+
+```csharp
+// 既存 EnsureGroup 相当（グループ生成＋スキーマ構成）
+internal static AddressableAssetGroup EnsureGroup(AddressableAssetSettings settings, string groupName, bool isLocal);
+
+// 既存 RegisterAsset 相当。duplicateAddressCollector / registeredGuids は任意（自動側は渡さない）。
+// 自動側からは label・group をこのメソッドの外で解決して渡す or 下記 RegisterSingle を使う。
+internal static void RegisterAsset(
+    AddressableAssetSettings settings, AddressableAssetGroup group, string guid,
+    string categoryRoot, string label,
+    AssetVaultDuplicateAddressCollector duplicateAddressCollector, HashSet<string> registeredGuids);
+
+// 自動登録用の単発登録。assetPath から isLocal/categoryRoot を受け取り、
+// ResolveCategoryFolder→GetGroupName/CreateLabel→EnsureGroup→RegisterAsset まで一括で行う。
+// 重複はログ警告のみ（ブロックしない）。
+internal static void RegisterSingle(AddressableAssetSettings settings, string assetPath, string categoryRoot, bool isLocal);
+
+// guid のエントリを管理グループから除去する（存在しなければ no-op）。
+internal static void RemoveEntry(AddressableAssetSettings settings, string guid);
+
+// 空になった管理グループ（Local_/Remote_）を削除する（既存 PruneStaleEntries の空グループ削除部分を共用）。
+internal static void PruneEmptyManagedGroups(AddressableAssetSettings settings);
+```
+
+- `EnsureGroup` が依存する `ConfigureBundledAssetGroupSchema` / `ConfigureContentUpdateGroupSchema` / プロファイル変数定数（`LocalBuildPathVariableName` 等）も一緒に Registrar 側へ移すか、`AssetVaultEditorOperations` に `internal` で残して参照させる。**どちらでもよいが二重定義は禁止**。
+- `AssetVaultEditorOperations.SyncAssetResource` は移設後の Registrar を呼ぶ形にリファクタし、**出力（登録結果・重複検出・プルーニング）が現状と一致**することを保証する。
+
+### 3. 追加・移動の自動処理
+`Assets/UniLab/AssetVault/Editor/AssetVaultAutoRegisterProcessor.cs`（新規）
+
+```csharp
+internal sealed class AssetVaultAutoRegisterProcessor : AssetPostprocessor
+{
+    private static void OnPostprocessAllAssets(
+        string[] importedAssets, string[] deletedAssets,
+        string[] movedAssets, string[] movedFromAssetPaths)
+}
+```
+
+処理:
+1. **早期スキップ**: ①Play 中（`EditorApplication.isPlayingOrWillChangePlaymode`）②設定が無い（`AssetVaultSetupSettings.TryLoad` が false。**自動生成しない**）③トグルがオフ ④Addressables 設定が無い（`AddressableSettingsAccessor.TryGetSettingsSilently`）。いずれかで即 return。
+2. ルート（Local 必須／Remote 任意）を取得しキャッシュ的に保持。判定は `IsUnderRoot` で行い、配下外のパスは即無視。
+3. バッチ全体を `AssetDatabase.StartAssetEditing()`/`StopAssetEditing()` で囲み、最後に1回だけ `SetDirty + SaveAssets`。
+4. **imported**: 各パスが Local/Remote いずれかの配下なら `RegisterSingle`（追加・再インポートとも idempotent）。
+5. **moved**（`movedAssets`=新パス, `movedFromAssetPaths`=旧パス, 同インデックス）:
+   - 新パスが配下 → `RegisterSingle`（移動で group/address/label が変わるため再登録）。移動後も guid は不変なのでアドレス更新が効く。
+   - 新パスが配下外 かつ 旧パスが配下 → 旧パスの guid（移動後も `AssetDatabase.AssetPathToGUID(新パス)` で取得可）で `RemoveEntry`。
+6. 処理後に `PruneEmptyManagedGroups`。
+7. **再入防止**: 上記の設定変更が再度 import を誘発しないこと（Addressables 設定変更は通常アセット再インポートを起こさないが、保存対象が Local/Remote 配下に入らないよう注意。設定アセットは `Assets/Generated/` 配下なので対象外）。
+
+### 4. 削除の自動処理
+`Assets/UniLab/AssetVault/Editor/AssetVaultAutoDeleteProcessor.cs`（新規）
+
+削除は `OnPostprocessAllAssets` の `deletedAssets` だと削除後で guid を引けないため、**削除前**フックで確実に取る:
+
+```csharp
+internal sealed class AssetVaultAutoDeleteProcessor : UnityEditor.AssetModificationProcessor
+{
+    private static AssetDeleteResult OnWillDeleteAsset(string assetPath, RemoveAssetOptions options)
+}
+```
+
+- 早期スキップ条件は §3 と同じ。
+- `assetPath` が Local/Remote 配下なら `AssetPathToGUID`→`RemoveEntry`。
+- 戻り値は `AssetDeleteResult.DidNotDelete`（Unity 既定の削除を妨げない）。
+- 空グループの掃除は削除完了後に走る §3 の `OnPostprocessAllAssets`→`PruneEmptyManagedGroups` に任せる（このフック時点ではまだ削除前）。
+- 注: Addressables 本体も削除エントリを掃除する場合があるが、`RemoveEntry` は no-op 安全なので二重でも問題ない。
+
+### 5. トグル（設定）
+`Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs`
+
+```csharp
+[Tooltip("オンにすると Local/Remote 配下のアセット追加・移動・削除を検知して Addressables を自動登録/更新します。既定オフ。")]
+[SerializeField] private bool _autoRegisterOnAssetChange;
+
+/// <summary>アセット変更時に自動登録を行うか。既定 false（オプトイン）。</summary>
+public bool AutoRegisterOnAssetChange => _autoRegisterOnAssetChange;
+```
+
+`Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs`
+- 既存 Inspector にトグルを表示（フォルダ指定の近く）。オンのとき「手動 Sync 不要になる」旨の `HelpBox` を出すと親切。
+
+### 6. テスト
+`Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs` に追加:
+- `IsUnderRoot`: 一致・配下・配下外・境界（`Assets/Local` と `Assets/LocalStuff/x` が false）。
+- `ResolveCategoryFolder`: ルート直下→root 自身 / サブフォルダ直下→第一階層 / 深いネスト→第一階層。
+
+> プロセッサ本体（AssetDatabase イベント依存）は EditMode 単体テストが難しいため、純粋ロジックのみテスト。動作は下記の手動確認で担保。
+
+---
+
+## 対象外（やらないこと）
+- 依存アセットの登録スキップ規約（`_` 始まりフォルダ）・共有依存グループ化（重複バンドル対策）。
+- 自動側での重複アドレスのブロッキング検出（ログ警告に留める。厳密検出は手動 Sync の責務）。
+- 大量インポート時の進捗バー／キャンセル（バッチ処理＋必要なら「件数が多いので手動 Sync 推奨」ログのみ）。
+
+## C# 規約（厳守）
+- ブロック namespace（`namespace Foo { ... }`）。ファイルスコープ禁止。
+- `if/for/foreach` は1行でも必ず `{}`。省略名禁止（`cfg`/`mgr` 等）。
+- public/internal メンバーに `/// <summary>`。コメントは日本語・Why 中心。
+- 不要な null チェックを足さない。ネスト最大3段（早期 return で平坦化）。
+
+## 受け入れ条件 / 手動確認
+1. トグル OFF: 従来どおり。アセット追加でエントリは自動生成されない（手動 Sync のみ反映）。
+2. トグル ON:
+   - Local/Remote のサブフォルダに Sprite を追加 → Addressables Groups に `Local_<sub>` グループでアドレス・ラベル付きエントリが**即**追加される。
+   - そのアセットを別サブフォルダへ移動 → グループ・アドレス・ラベルが移動先に追従する。
+   - ルート配下から外（例 `Assets/` 直下）へ移動 → エントリが除去される。
+   - アセットを削除 → エントリが除去され、空になった管理グループが消える。
+3. その結果が、同じ状態で**手動 Sync を実行した場合と一致**すること（最重要：自動とSyncで差が出ない）。
+4. Play 中は自動処理が走らない。
+5. 既存 EditMode テスト（`AssetVaultAddressingTest` 含む）が green。


### PR DESCRIPTION
## 概要

トグル ON で Local/Remote ルート配下のアセット追加・移動・削除を検知し、Addressables のグループ所属・アドレス・ラベルを差分で自動追従させます（手動 Sync 押し忘れ対策）。オプトイン（既定オフ）。

## 主な変更

- **AssetVaultGroupRegistrar** — 登録コアを手動 Sync と共用に抽出
- **AssetVaultAutoRegisterProcessor** — AssetPostprocessor：追加・移動。フォルダ移動は配下を展開して追従
- **AssetVaultAutoDeleteProcessor** — AssetModificationProcessor：削除前に guid 確定。フォルダ削除は配下を展開
- **AssetVaultSetupSettings** にトグル `AutoRegisterOnAssetChange`、Inspector に ON/OFF の HelpBox
- 純粋ロジック `IsUnderRoot`/`ResolveCategoryFolder` + EditMode テスト追加
- 移動時のラベル残留を修正（登録時に既存ラベルをクリアしてから付与。手動 Sync 側にも適用）
- perf: バッチ内グループキャッシュで EnsureGroup の重複実行を排除

## 設計方針

- 自動処理後の状態が手動 Sync の結果と一致するよう実装
- 重複アドレスの厳密検出は手動 Sync の責務（自動側はスキップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)