### PR TITLE
feat: AssetVault に skip フォルダ規約（_ 始まりは登録対象外）

### DIFF
--- a/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultAddressingTest.cs
@@ -74,6 +74,18 @@ namespace UniLab.AssetVault.Editor.Tests
         }
 
         [Test]
+        public void IsInSkipFolder_アンダースコア始まりフォルダ配下だけをtrueにする()
+        {
+            // 直下・サブフォルダ直下の「_」フォルダ、ネストした「_」フォルダはスキップ対象。
+            Assert.IsTrue(AssetVaultAddressing.IsInSkipFolder("Assets/Local/_Src/atlas_src.png", "Assets/Local"));
+            Assert.IsTrue(AssetVaultAddressing.IsInSkipFolder("Assets/Local/Icons/_Src/clip.anim", "Assets/Local"));
+            // 通常フォルダ配下・ルート直下・ファイル名先頭の「_」はスキップ対象外。
+            Assert.IsFalse(AssetVaultAddressing.IsInSkipFolder("Assets/Local/Icons/coin.png", "Assets/Local"));
+            Assert.IsFalse(AssetVaultAddressing.IsInSkipFolder("Assets/Local/coin.png", "Assets/Local"));
+            Assert.IsFalse(AssetVaultAddressing.IsInSkipFolder("Assets/Local/_coin.png", "Assets/Local"));
+        }
+
+        [Test]
         public void IsManagedGroupName_LocalRemoteプレフィックスのみ管理対象と判定する()
         {
             Assert.IsTrue(AssetVaultAddressing.IsManagedGroupName("Local_Foo"));

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultAddressing.cs
@@ -15,6 +15,9 @@ namespace UniLab.AssetVault.Editor
         /// <summary>Remote 配信グループ名のプレフィックスです。</summary>
         public const string RemoteGroupPrefix = "Remote_";
 
+        /// <summary>依存アセット置き場フォルダの名前プレフィックスです。配下は Addressables 登録対象外（依存として同梱）になります。</summary>
+        public const string SkipFolderPrefix = "_";
+
         /// <summary>
         /// アセットパスから、カテゴリルート相対・拡張子なしのアドレスを作ります。
         /// 例: ("Assets/Remote/Characters/hero.prefab", "Assets/Remote") → "Characters/hero"。
@@ -96,6 +99,34 @@ namespace UniLab.AssetVault.Editor
 
             var firstFolderName = relativePath.Substring(0, separatorIndex);
             return normalizedCategoryRoot + "/" + firstFolderName;
+        }
+
+        /// <summary>
+        /// assetPath が categoryRoot 配下の「_」始まりフォルダ（依存アセット置き場）の中にあるかを判定します。
+        /// 単一利用の依存（prefab 専用 AnimationClip、SpriteAtlas の元 Sprite 等）をエントリ登録から除外するために使います。
+        /// 判定対象はフォルダ要素のみで、ファイル名先頭の「_」は対象外です。
+        /// </summary>
+        public static bool IsInSkipFolder(string assetPath, string categoryRoot)
+        {
+            var normalizedAssetPath = NormalizeAssetPath(assetPath);
+            var normalizedCategoryRoot = NormalizeAssetPath(categoryRoot);
+            if (!IsUnderRoot(normalizedAssetPath, normalizedCategoryRoot))
+            {
+                return false;
+            }
+
+            var relativePath = normalizedAssetPath.Substring(normalizedCategoryRoot.Length).TrimStart('/');
+            var segments = relativePath.Split('/');
+            // 末尾要素はファイル名なので除外し、フォルダ要素だけを見る。
+            for (var index = 0; index < segments.Length - 1; index++)
+            {
+                if (segments[index].StartsWith(SkipFolderPrefix, StringComparison.Ordinal))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -238,6 +238,12 @@ namespace UniLab.AssetVault.Editor
             var subFolders = AssetDatabase.GetSubFolders(categoryRoot);
             foreach (var subFolder in subFolders)
             {
+                // 依存アセット置き場（"_" 始まりフォルダ）はグループ化・登録しない。
+                if (Path.GetFileName(subFolder).StartsWith(AssetVaultAddressing.SkipFolderPrefix, System.StringComparison.Ordinal))
+                {
+                    continue;
+                }
+
                 var groupName = AssetVaultAddressing.GetGroupName(subFolder, isLocal);
                 var group = AssetVaultGroupRegistrar.EnsureGroup(settings, groupName, isLocal);
                 var label = AssetVaultAddressing.CreateLabel(subFolder);

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultGroupRegistrar.cs
@@ -90,6 +90,12 @@ namespace UniLab.AssetVault.Editor
                 return;
             }
 
+            // 依存アセット置き場（"_" 始まりフォルダ）は登録対象外。手動 Sync ではこの未登録分を PruneStaleEntries が掃除する。
+            if (AssetVaultAddressing.IsInSkipFolder(assetPath, categoryRoot))
+            {
+                return;
+            }
+
             var entry = settings.CreateOrMoveEntry(guid, group);
             if (entry == null)
             {
@@ -125,6 +131,13 @@ namespace UniLab.AssetVault.Editor
             var guid = AssetDatabase.AssetPathToGUID(assetPath);
             if (string.IsNullOrEmpty(guid))
             {
+                return;
+            }
+
+            // 依存アセット置き場（"_" 始まりフォルダ）へ入った/移動した場合は、登録せず既存エントリを除去する。
+            if (AssetVaultAddressing.IsInSkipFolder(assetPath, categoryRoot))
+            {
+                RemoveEntry(settings, guid);
                 return;
             }
 

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -69,6 +69,38 @@ IReadOnlyList<Sprite> icons = await _assetVault.LoadAssetsAsync<Sprite>(this, "I
 - 明示 Scope 版は `scope.LoadAssetsAsync<T>(label, ct)`。
 - **規約の指針**: ラベルは「型」ではなく「**ロード単位（用途）**」で切る（例 `HomeIcon` / `BattleIcon`）。型分割（`Icons/Sprite`, `Icons/Prefab`）は `T` が捌くので不要。
 
+### 依存アセットと skip フォルダ（`_` 始まり）
+
+`Local/Remote` 配下で **`_` 始まりのフォルダは登録対象外**（Sync・自動登録とも）。「コードから直接ロードしない依存アセット」の置き場に使う。
+
+判断基準は「**address/label でロードする起点か？**」:
+
+- **起点 → 通常フォルダ（登録される）**: prefab / ScriptableObject / 単体 Sprite / `.spriteatlas` 本体。
+- **依存のみ → `_` フォルダ（登録されない）**: その起点専用の AnimationClip / AnimatorController / Material / Shader / **SpriteAtlas の元 Sprite** 等。登録されなくても、起点をロードすれば**依存として自動同梱**される（1コピー）。
+
+```
+Local/
+  Characters/
+    hero.prefab          ← 登録（address: Characters/hero, label: Characters）
+    _src/                ← 登録されない（hero 専用の依存置き場）
+      hero.anim
+      hero_mat.mat
+  UI/
+    icons.spriteatlas    ← 登録（アトラス本体はロード可）
+    _atlas/              ← 登録されない（アトラスの元 Sprite。重複・実行時バインド事故を防ぐ）
+      coin.png
+```
+
+**「登録されない」≠「ビルドに入らない」**: `_` が制御するのは Addressable エントリ化（= 個別ロードの口）だけ。`_` 配下でも、登録済みアセットから参照されていれば依存として同梱される。逆に**どこからも参照されない `_` 配下アセットは、登録も参照もされず＝ビルドに含まれない（ロード手段がない）**点に注意。
+
+**重要な例外 — 共有依存は `_` に入れない**:
+
+- `_`（未登録）にすると、その依存は**参照する各バンドルに重複コピー**される。これは**単一利用の依存にだけ**正しい。
+- **複数の起点／複数グループから参照される共有依存**（共通 Material・共有アトラス等）は、`_` ではなく**通常フォルダに置いて登録**する（1バンドルに集約され重複しない）。
+- 重複の検出は手で追わず **Addressables Analyze → Check Duplicate Bundle Dependencies**。出たものを `_` から通常フォルダ（共有グループ）へ移す。
+
+> SpriteAtlas: 本体は登録、元 Sprite は `_` で除外、が基本。直接参照されないアトラス（名前解決で使う等）は `SpriteAtlasManager.atlasRequested` を Addressables で配線して動的供給する。
+
 > 以降は **上位: 明示 Scope** 方式の説明。共有寿命や画面単位の一括解放が要るときに使う。
 
 ## 明示 Scope の原則（最初に押さえる3点）


### PR DESCRIPTION
## 概要

Local/Remote 配下の `_` 始まりフォルダを Addressables 登録対象外にし、単一利用の依存アセット（prefab 専用 AnimationClip、SpriteAtlas の元 Sprite 等）の置き場として使えるようにしました。Sync・自動登録の両方に適用されます。

## 主な変更

- **AssetVaultAddressing**: `SkipFolderPrefix = "_"` を定義し、純粋関数 `IsInSkipFolder` を追加。フォルダ要素のみ判定し、ファイル名先頭の `_` は対象外です。
- **AssetVaultGroupRegistrar**: RegisterAsset は skip 配下を登録しない。Sync は PruneStaleEntries が掃除します。RegisterSingle は skip へ移動した既存エントリを除去し、auto は自己修復します。
- **AssetVaultEditorOperations.SyncCategory**: 直下の `_` サブフォルダをグループ化・登録ごとスキップします。
- **テスト・ドキュメント**: EditMode テスト追加、usage ドキュメントに「依存アセットと skip フォルダ／SpriteAtlas」節を追加しました。

## 注意

「登録されない」≠「ビルドに入らない」です。参照されていれば依存として同梱されます。共有依存は `_` ではなく通常フォルダに置いて登録してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)