### PR TITLE
feat: AssetVault に規約チェッカー(Dashboard統合)とキャッシュ Prewarm/統計 API を追加

### DIFF
--- a/Assets/AddressableAssetsData.meta
+++ b/Assets/AddressableAssetsData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3c76acb73754a4e9e90774cc7d9bef4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetGroupSortSettings.asset
@@ -12,4 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dea69d41f90c6ea4fa55c27c1d60c145, type: 3}
   m_Name: AddressableAssetGroupSortSettings
   m_EditorClassIdentifier: Unity.Addressables.Editor::UnityEditor.AddressableAssets.Settings.GroupSchemas.AddressableAssetGroupSortSettings
-  sortOrder: []
+  sortOrder:
+  - 86141a37e8dc043aeade9ab37acdd742

--- a/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -24,11 +24,11 @@ MonoBehaviour:
   m_InternalBundleIdMode: 1
   m_AssetLoadMode: 0
   m_BundledAssetProviderType:
-    m_AssemblyName: 
-    m_ClassName: 
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.BundledAssetProvider
   m_AssetBundleProviderType:
-    m_AssemblyName: 
-    m_ClassName: 
+    m_AssemblyName: Unity.ResourceManager, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
+    m_ClassName: UnityEngine.ResourceManagement.ResourceProviders.AssetBundleProvider
   m_IgnoreUnsupportedFilesInBuild: 0
   m_UniqueBundleIds: 0
   m_EnableJsonCatalog: 0
@@ -71,8 +71,16 @@ MonoBehaviour:
       m_Values:
       - m_Id: 077fc26c820ab4f7db0edc9704f25599
         m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
+      - m_Id: 2cc6ca3afdfa24ea5bf4fead7a38d24d
+        m_Value: 'ServerData/[BuildTarget]'
+      - m_Id: 3026738fa0939464e943d4b16526b538
+        m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+      - m_Id: 515f62981af234b798321aab7b28d1bb
+        m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
       - m_Id: 875bd0507b73a45b287b7e99ed8d700f
         m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+      - m_Id: 919bd71c3207e4598bd8f4fc563e5e93
+        m_Value: '{UniLab.AssetVault.AssetVaultRuntime.BaseUrl}/{UniLab.AssetVault.AssetVaultRuntime.ContentPath}/[BuildTarget]'
       - m_Id: 9db704db3e0d047a79acb56749696b71
         m_Value: 'ServerData/[BuildTarget]'
       - m_Id: a67f2496d310e41499a3dc6049574dfd
@@ -83,8 +91,20 @@ MonoBehaviour:
     - m_Id: 077fc26c820ab4f7db0edc9704f25599
       m_Name: Local.BuildPath
       m_InlineUsage: 0
+    - m_Id: 2cc6ca3afdfa24ea5bf4fead7a38d24d
+      m_Name: RemoteBuildPath
+      m_InlineUsage: 0
+    - m_Id: 3026738fa0939464e943d4b16526b538
+      m_Name: LocalLoadPath
+      m_InlineUsage: 0
+    - m_Id: 515f62981af234b798321aab7b28d1bb
+      m_Name: LocalBuildPath
+      m_InlineUsage: 0
     - m_Id: 875bd0507b73a45b287b7e99ed8d700f
       m_Name: Local.LoadPath
+      m_InlineUsage: 0
+    - m_Id: 919bd71c3207e4598bd8f4fc563e5e93
+      m_Name: RemoteLoadPath
       m_InlineUsage: 0
     - m_Id: 9db704db3e0d047a79acb56749696b71
       m_Name: Remote.BuildPath
@@ -100,6 +120,8 @@ MonoBehaviour:
     m_LabelNames:
     - default
     - sample
+    - Test1
+    - TestRemote
   m_SchemaTemplates: []
   m_GroupTemplateObjects:
   - {fileID: 11400000, guid: 801f4745c21584205a8076420cc01fb4, type: 2}

--- a/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
+++ b/Assets/AddressableAssetsData/AssetGroups/Default Local Group.asset
@@ -14,13 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: Unity.Addressables.Editor::UnityEditor.AddressableAssets.Settings.AddressableAssetGroup
   m_GroupName: Default Local Group
   m_GUID: 86141a37e8dc043aeade9ab37acdd742
-  m_SerializeEntries:
-  - m_GUID: fa940ab9511cf4015b845ea86d75b39b
-    m_Address: sample_sprite
-    m_ReadOnly: 0
-    m_SerializedLabels:
-    - sample
-    FlaggedDuringContentUpdateRestriction: 0
+  m_SerializeEntries: []
   m_ReadOnly: 0
   m_Settings: {fileID: 11400000, guid: 81b7d407eb64345639f52801ed704ac0, type: 2}
   m_SchemaSet:

--- a/Assets/AddressableAssetsData/OSX.meta
+++ b/Assets/AddressableAssetsData/OSX.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: de425019af09e41bf9cf9b2189ce5e16
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/AssetVault/AssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCache.cs
@@ -18,6 +18,8 @@ namespace UniLab.AssetVault
         private readonly Func<float> _timeProvider;
         private readonly Dictionary<CacheKey, Entry> _entries = new();
         private readonly List<CacheKey> _reclaimBuffer = new();
+        // Prewarm で pin したエントリの保持参照。Dispose（参照-1）するまで TTL/LRU 解放から守る。
+        private readonly Dictionary<CacheKey, IDisposable> _prewarmed = new();
 
         /// <summary>
         /// 設定（既定は <see cref="AssetVaultCacheSettings.Default"/>）と時刻プロバイダ（既定は realtimeSinceStartup）でキャッシュを作成します。
@@ -83,11 +85,66 @@ namespace UniLab.AssetVault
             EnforceCapacity();
         }
 
+        /// <inheritdoc />
+        public async UniTask PrewarmAsync<T>(IReadOnlyList<string> keys, CancellationToken cancellationToken)
+        {
+            if (keys == null)
+            {
+                throw new AssetVaultException("AssetVaultCache.PrewarmAsync: keys is null.");
+            }
+
+            foreach (var key in keys)
+            {
+                var cacheKey = new CacheKey(key, typeof(T));
+                if (_prewarmed.ContainsKey(cacheKey))
+                {
+                    // 二重 prewarm は無駄な参照を増やさないようにスキップする。
+                    continue;
+                }
+
+                // Acquire で参照カウント+1 し、その参照を保持して TTL/LRU 解放から守る（= pin）。
+                var reference = await AcquireAsync<T>(key, cancellationToken);
+                _prewarmed[cacheKey] = reference;
+            }
+        }
+
+        /// <inheritdoc />
+        public void ReleasePrewarm()
+        {
+            foreach (var reference in _prewarmed.Values)
+            {
+                reference.Dispose();
+            }
+
+            _prewarmed.Clear();
+        }
+
+        /// <inheritdoc />
+        public AssetVaultCacheStats GetStats()
+        {
+            var referencedEntryCount = 0;
+            var totalReferenceCount = 0;
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.RefCount > 0)
+                {
+                    referencedEntryCount++;
+                }
+
+                totalReferenceCount += pair.Value.RefCount;
+            }
+
+            return new AssetVaultCacheStats(_entries.Count, referencedEntryCount, _prewarmed.Count, totalReferenceCount);
+        }
+
         /// <summary>
         /// 全エントリを参照カウントに関わらず解放します。
         /// </summary>
         public void Dispose()
         {
+            // pin 参照は破棄するエントリと一緒に解放されるため、保持リストはクリアするだけでよい。
+            _prewarmed.Clear();
+
             foreach (var pair in _entries)
             {
                 if (pair.Value.Handle.IsValid())

--- a/Assets/UniLab/AssetVault/AssetVaultCacheStats.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheStats.cs
@@ -1,0 +1,31 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// <see cref="IAssetVaultCache"/> の現在の占有状況スナップショットです（ランタイム診断・デバッグ表示用）。
+    /// </summary>
+    public readonly struct AssetVaultCacheStats
+    {
+        public AssetVaultCacheStats(int entryCount, int referencedEntryCount, int pinnedEntryCount, int totalReferenceCount)
+        {
+            EntryCount = entryCount;
+            ReferencedEntryCount = referencedEntryCount;
+            PinnedEntryCount = pinnedEntryCount;
+            TotalReferenceCount = totalReferenceCount;
+        }
+
+        /// <summary>cache が保持しているエントリ総数です。</summary>
+        public int EntryCount { get; }
+
+        /// <summary>参照カウントが 1 以上（使用中）のエントリ数です。</summary>
+        public int ReferencedEntryCount { get; }
+
+        /// <summary>Prewarm で pin 中のエントリ数です。</summary>
+        public int PinnedEntryCount { get; }
+
+        /// <summary>全エントリの参照カウント合計です。</summary>
+        public int TotalReferenceCount { get; }
+
+        /// <summary>参照カウント 0（TTL/LRU の解放待ち）のエントリ数です。</summary>
+        public int UnreferencedEntryCount => EntryCount - ReferencedEntryCount;
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultCacheStats.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheStats.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58720a8b53a06471eab4ddff9c561c90

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.AddressableAssets.Settings;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetVault 管理グループ（Local_/Remote_）の規約違反を Addressables 設定から検出します。
+    /// 検出対象: 重複アドレス・孤立ラベル・依存アセットのエントリ化（skip 漏れ候補）。
+    /// </summary>
+    internal static class AssetVaultConventionChecker
+    {
+        /// <summary>
+        /// 管理グループ全体を走査して規約違反を一覧で返します。違反が無ければ空リストです。
+        /// </summary>
+        internal static IReadOnlyList<AssetVaultViolation> Check(AddressableAssetSettings settings)
+        {
+            var violations = new List<AssetVaultViolation>();
+            var managedEntries = CollectManagedEntries(settings);
+
+            AddDuplicateAddressViolations(managedEntries, violations);
+            AddOrphanLabelViolations(settings, violations);
+            AddDependencyEntryViolations(managedEntries, violations);
+            return violations;
+        }
+
+        private static List<AddressableAssetEntry> CollectManagedEntries(AddressableAssetSettings settings)
+        {
+            var entries = new List<AddressableAssetEntry>();
+            foreach (var group in settings.groups)
+            {
+                if (group == null || !AssetVaultAddressing.IsManagedGroupName(group.Name))
+                {
+                    continue;
+                }
+
+                entries.AddRange(group.entries.Where(entry => entry != null));
+            }
+
+            return entries;
+        }
+
+        // 同一アドレスが2件以上の管理エントリに付いている場合に違反とする（実行時ロードが壊れるため）。
+        private static void AddDuplicateAddressViolations(IReadOnlyList<AddressableAssetEntry> managedEntries, List<AssetVaultViolation> violations)
+        {
+            var duplicateGroups = managedEntries
+                .GroupBy(entry => entry.address)
+                .Where(group => group.Count() > 1);
+
+            foreach (var duplicateGroup in duplicateGroups)
+            {
+                var paths = string.Join(", ", duplicateGroup.Select(entry => entry.AssetPath));
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.DuplicateAddress,
+                    $"重複アドレス '{duplicateGroup.Key}': {paths}"));
+            }
+        }
+
+        // どのエントリも使っていないラベル（auto 登録の入れ替えで残った孤立ラベル等）を違反とする。
+        private static void AddOrphanLabelViolations(AddressableAssetSettings settings, List<AssetVaultViolation> violations)
+        {
+            var usedLabels = CollectUsedLabels(settings);
+            foreach (var label in settings.GetLabels())
+            {
+                if (usedLabels.Contains(label))
+                {
+                    continue;
+                }
+
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.OrphanLabel,
+                    $"孤立ラベル '{label}'（どのエントリも使用していません）"));
+            }
+        }
+
+        private static HashSet<string> CollectUsedLabels(AddressableAssetSettings settings)
+        {
+            var usedLabels = new HashSet<string>();
+            foreach (var group in settings.groups)
+            {
+                if (group == null)
+                {
+                    continue;
+                }
+
+                foreach (var entry in group.entries)
+                {
+                    if (entry != null)
+                    {
+                        usedLabels.UnionWith(entry.labels);
+                    }
+                }
+            }
+
+            return usedLabels;
+        }
+
+        // 他の管理エントリの依存でもあるアセットが、自身もエントリ登録されている場合に違反とする。
+        // 単一利用なら "_" skip フォルダへ、共有なら共有グループへ寄せると重複バンドルを防げる。
+        private static void AddDependencyEntryViolations(IReadOnlyList<AddressableAssetEntry> managedEntries, List<AssetVaultViolation> violations)
+        {
+            var managedPaths = new HashSet<string>(managedEntries.Select(entry => entry.AssetPath));
+            var referencedAsDependency = CollectEntriesReferencedAsDependency(managedEntries, managedPaths);
+
+            foreach (var path in referencedAsDependency)
+            {
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.DependencyRegisteredAsEntry,
+                    $"依存アセットがエントリ登録されています（'_' skip フォルダ か共有グループ化を検討）: {path}"));
+            }
+        }
+
+        private static HashSet<string> CollectEntriesReferencedAsDependency(IReadOnlyList<AddressableAssetEntry> managedEntries, HashSet<string> managedPaths)
+        {
+            var referencedAsDependency = new HashSet<string>();
+            foreach (var entry in managedEntries)
+            {
+                // 直接依存のみを見る（recursive=false）。間接依存は親が同梱するため対象外。
+                var dependencies = AssetDatabase.GetDependencies(entry.AssetPath, false);
+                foreach (var dependency in dependencies)
+                {
+                    if (dependency != entry.AssetPath && managedPaths.Contains(dependency))
+                    {
+                        referencedAsDependency.Add(dependency);
+                    }
+                }
+            }
+
+            return referencedAsDependency;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 776057a60032b4234976d960e4270a0c

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -220,6 +220,21 @@ namespace UniLab.AssetVault.Editor
                 remoteFolderPath);
         }
 
+        // --- Conventions ---
+
+        /// <summary>
+        /// 管理グループの規約違反（重複アドレス・孤立ラベル・依存アセットのエントリ化）を検査し、一覧で返します。Dashboard 表示用。
+        /// </summary>
+        public static IReadOnlyList<AssetVaultViolation> CheckConventions()
+        {
+            if (!AddressableSettingsAccessor.TryGetSettingsSilently(out var settings))
+            {
+                return System.Array.Empty<AssetVaultViolation>();
+            }
+
+            return AssetVaultConventionChecker.Check(settings);
+        }
+
         // --- Internal helpers ---
 
         private static void SyncCategory(

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs
@@ -1,0 +1,23 @@
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetVault 規約違反の1件です（Dashboard 表示用の読み取り専用データ）。
+    /// </summary>
+    public readonly struct AssetVaultViolation
+    {
+        /// <summary>
+        /// 違反の種別と説明文を指定して1件を生成します。<see cref="AssetVaultConventionChecker"/> が検出時に呼びます。
+        /// </summary>
+        public AssetVaultViolation(AssetVaultViolationType violationType, string message)
+        {
+            ViolationType = violationType;
+            Message = message;
+        }
+
+        /// <summary>違反の種別です。</summary>
+        public AssetVaultViolationType ViolationType { get; }
+
+        /// <summary>違反内容の説明（対象アドレス・アセットパス等を含む）です。</summary>
+        public string Message { get; }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 67fe62eb2b4a54d7a836d1b7ff89ce85

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultViolationType.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultViolationType.cs
@@ -1,0 +1,20 @@
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// AssetVault 管理グループの規約違反の種別です。
+    /// </summary>
+    public enum AssetVaultViolationType
+    {
+        /// <summary>未分類（既定値）。</summary>
+        None = 0,
+
+        /// <summary>同一アドレスが複数エントリに付いている（実行時ロードを壊す）。</summary>
+        DuplicateAddress,
+
+        /// <summary>どのエントリも使用していない孤立ラベル。</summary>
+        OrphanLabel,
+
+        /// <summary>他エントリの依存でもあるアセットがエントリ登録されている（"_" skip フォルダ／共有グループ化の候補）。</summary>
+        DependencyRegisteredAsEntry,
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultViolationType.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultViolationType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ae909a8aca3a842fc9b7beb19f6036fb

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using UniLab.AssetVault.Debugging;
 using UnityEditor;
 using UnityEngine;
@@ -6,7 +7,7 @@ namespace UniLab.AssetVault.Editor
 {
     /// <summary>
     /// AssetVault の Addressables 構成を一望・操作する統合ダッシュボードです。
-    /// Setup / Build / Debug Override / Status の各セクションを提供し、
+    /// Setup / Build / Debug Override / Status / Conventions の各セクションを提供し、
     /// 操作はすべて <see cref="AssetVaultEditorOperations"/> に委譲します。
     /// </summary>
     public sealed class AssetVaultWindow : EditorWindow
@@ -20,6 +21,8 @@ namespace UniLab.AssetVault.Editor
 
         private AssetVaultStatus _status;
         private bool _statusLoaded;
+        private IReadOnlyList<AssetVaultViolation> _violations;
+        private bool _violationsChecked;
         private Vector2 _scrollPosition;
 
         [MenuItem(WindowMenuPath, false, WindowMenuPriority)]
@@ -46,6 +49,8 @@ namespace UniLab.AssetVault.Editor
             DrawDebugOverrideSection();
             EditorGUILayout.Space(SectionSpacing);
             DrawStatusSection();
+            EditorGUILayout.Space(SectionSpacing);
+            DrawConventionsSection();
 
             EditorGUILayout.EndScrollView();
         }
@@ -136,6 +141,44 @@ namespace UniLab.AssetVault.Editor
                 EditorGUILayout.LabelField("Local Folder", string.IsNullOrEmpty(_status.LocalFolderPath) ? "未設定" : _status.LocalFolderPath);
                 EditorGUILayout.LabelField("Remote Folder", string.IsNullOrEmpty(_status.RemoteFolderPath) ? "未設定（任意）" : _status.RemoteFolderPath);
             }
+        }
+
+        private void DrawConventionsSection()
+        {
+            DrawHeader("Conventions");
+            if (DrawActionButton(
+                "Check Conventions",
+                "管理グループの規約違反（重複アドレス・孤立ラベル・依存アセットのエントリ化）を検査します。Addressables 標準の Analyze を補う、AssetVault 規約の健全性チェックです。"))
+            {
+                _violations = AssetVaultEditorOperations.CheckConventions();
+                _violationsChecked = true;
+                Repaint();
+            }
+
+            if (!_violationsChecked)
+            {
+                return;
+            }
+
+            if (_violations.Count == 0)
+            {
+                EditorGUILayout.HelpBox("規約違反は見つかりませんでした。", MessageType.Info);
+                return;
+            }
+
+            EditorGUILayout.LabelField($"{_violations.Count} 件の規約違反", EditorStyles.miniBoldLabel);
+            foreach (var violation in _violations)
+            {
+                EditorGUILayout.HelpBox($"[{violation.ViolationType}] {violation.Message}", ToMessageType(violation.ViolationType));
+            }
+        }
+
+        // DuplicateAddress は実行時ロードを壊す致命傷のため Error、それ以外（孤立ラベル・依存エントリ化）は是正推奨の Warning として表示する。
+        private static MessageType ToMessageType(AssetVaultViolationType violationType)
+        {
+            return violationType == AssetVaultViolationType.DuplicateAddress
+                ? MessageType.Error
+                : MessageType.Warning;
         }
 
         private void RefreshStatus()

--- a/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 
@@ -20,5 +21,22 @@ namespace UniLab.AssetVault
         /// 期限切れ（TTL 超過）・上限超過（LRU）の未参照エントリを今すぐ解放します。任意タイミングで呼べます。
         /// </summary>
         void Trim();
+
+        /// <summary>
+        /// keys のアセットを型 <typeparamref name="T"/> として事前ロードし、cache に保持（pin）します。
+        /// ロード待ちを使用前（ローディング画面・シーン遷移）に前倒しし、以降の <see cref="AcquireAsync{T}"/> を即時化します。
+        /// pin した分は <see cref="ReleasePrewarm"/> を呼ぶまで TTL/LRU で破棄されません。メモリ予算のため範囲を区切って使ってください。
+        /// </summary>
+        UniTask PrewarmAsync<T>(IReadOnlyList<string> keys, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// <see cref="PrewarmAsync{T}"/> で pin した保持をすべて解放します（参照カウントを手放し、以降は TTL/LRU 管理に戻します）。
+        /// </summary>
+        void ReleasePrewarm();
+
+        /// <summary>
+        /// cache の現在の占有状況（エントリ数・参照中・pin 中・参照合計）のスナップショットを取得します。ランタイム診断用です。
+        /// </summary>
+        AssetVaultCacheStats GetStats();
     }
 }

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -333,6 +333,36 @@ reference.Dispose(); // 参照-1。0 でも TTL 猶予中はキャッシュ保�
 - 参照0でも **TTL（既定10秒）** の間は保持＝出入りの激しいプールで再ロード（churn）しない。
 - **LRU（既定64件）** で溜め込みすぎを防止。設定は `AssetVaultCacheSettings`。
 
+### Prewarm: 事前ロードで本番を即時化
+
+ロード待ちを「暇な瞬間（ローディング画面・遷移）」へ前倒しする。`PrewarmAsync<T>(keys)` で cache に載せて **pin**（保持）し、以降の `AcquireAsync` を即時（cache ヒット）にする。
+
+```csharp
+// ローディング画面で先読み（pin される＝TTL で消えない）
+await _cache.PrewarmAsync<Sprite>(new[] { "Icons/coin", "Icons/gem" }, ct);
+...
+// 本番：cache ヒットで即時、hitch なし
+var reference = await _cache.AcquireAsync<Sprite>("Icons/coin", ct);
+...
+// そのシーン/バトルを抜けるとき、pin を解放（以降は TTL/LRU 管理に戻る）
+_cache.ReleasePrewarm();
+```
+
+- **Remote アセットは先に `DownloadAsync(labels)`**（バイトをディスクへ）→ `PrewarmAsync`（メモリへ展開）の順。Prewarm は通信の一段上。
+- **メモリ予算のため範囲を区切る**: そのシーン/バトルの集合だけ prewarm → 終わったら `ReleasePrewarm`。全部 prewarm は禁物。
+- pin 中は TTL/LRU で破棄されない。`ReleasePrewarm` を呼ばないと載りっぱなしになる。
+
+### ランタイム診断: `GetStats()`
+
+cache の占有状況スナップショットを取得する（デバッグ表示・リーク調査用）。
+
+```csharp
+var stats = _cache.GetStats();
+// EntryCount / ReferencedEntryCount / PinnedEntryCount / TotalReferenceCount / UnreferencedEntryCount
+```
+
+> Editor 側では Dashboard の **Conventions**（Check Conventions）で、重複アドレス・孤立ラベル・依存アセットのエントリ化（skip 漏れ候補）を検査できる。Addressables 標準の Analyze を補う AssetVault 規約の健全性チェック。
+
 ### スロット: 1枚を差し替える要素（プール要素向け）
 
 ```csharp


### PR DESCRIPTION
- 規約違反チェッカー `AssetVaultConventionChecker` を追加。3種検出: 重複アドレス(実行時ロードを壊すため Error 表示)・孤立ラベル・依存アセットのエントリ化(_ skip フォルダ/共有グループ化の候補)
- Dashboard (`AssetVaultWindow`) に Conventions セクションを統合。違反件数サマリと種別ごとの重大度(Error/Warning)表示
- `AssetVaultCache` に Prewarm/統計 API (`PrewarmAsync`/`ReleasePrewarm`/`GetStats`) と `AssetVaultCacheStats` を追加