### PR TITLE
feat: AssetVault のビルド前規約ゲートと Dashboard 英語化

### DIFF
--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
@@ -53,7 +53,7 @@ namespace UniLab.AssetVault.Editor
                 var paths = string.Join(", ", duplicateGroup.Select(entry => entry.AssetPath));
                 violations.Add(new AssetVaultViolation(
                     AssetVaultViolationType.DuplicateAddress,
-                    $"重複アドレス '{duplicateGroup.Key}': {paths}"));
+                    $"Duplicate address '{duplicateGroup.Key}': {paths}"));
             }
         }
 
@@ -70,7 +70,7 @@ namespace UniLab.AssetVault.Editor
 
                 violations.Add(new AssetVaultViolation(
                     AssetVaultViolationType.OrphanLabel,
-                    $"孤立ラベル '{label}'（どのエントリも使用していません）"));
+                    $"Orphan label '{label}' (not used by any entry)"));
             }
         }
 
@@ -107,7 +107,7 @@ namespace UniLab.AssetVault.Editor
             {
                 violations.Add(new AssetVaultViolation(
                     AssetVaultViolationType.DependencyRegisteredAsEntry,
-                    $"依存アセットがエントリ登録されています（'_' skip フォルダ か共有グループ化を検討）: {path}"));
+                    $"Dependency asset is registered as an entry (consider a '_' skip folder or a shared group): {path}"));
             }
         }
 

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultEditorOperations.cs
@@ -23,6 +23,8 @@ namespace UniLab.AssetVault.Editor
         private const string ContentUpdateFailedMessage = "Addressables content update build failed.";
         private const string NewBuildCompletedMessage = "Addressables new build completed.";
         private const string ContentUpdateCompletedMessage = "Addressables content update build completed.";
+        private const string ConventionGateFailedMessageFormat = "AssetVault build aborted due to convention violations. Resolve the following fatal violations (e.g. duplicate addresses that break runtime loading) and run again:\n{0}";
+        private const string ConventionWarningMessageFormat = "[AssetVault convention] {0}";
 
         // --- Build ---
 
@@ -33,6 +35,12 @@ namespace UniLab.AssetVault.Editor
         public static bool BuildNew()
         {
             if (!AddressableSettingsAccessor.TryGetSettings(out _))
+            {
+                return false;
+            }
+
+            // 重複アドレス等の致命的違反を抱えたままビルドすると実行時ロードが壊れるため、ビルド前に必ず規約ゲートを通す。
+            if (!PassesConventionGate())
             {
                 return false;
             }
@@ -71,6 +79,12 @@ namespace UniLab.AssetVault.Editor
         public static bool BuildContentUpdate()
         {
             if (!AddressableSettingsAccessor.TryGetSettings(out var settings))
+            {
+                return false;
+            }
+
+            // New Build と同様、差分ビルドでも致命的な規約違反があれば中断する。
+            if (!PassesConventionGate())
             {
                 return false;
             }
@@ -233,6 +247,38 @@ namespace UniLab.AssetVault.Editor
             }
 
             return AssetVaultConventionChecker.Check(settings);
+        }
+
+        /// <summary>
+        /// ビルド前ゲート。規約違反を検査し、Error（実行時ロードを壊す致命的違反）が1件でもあればビルドを止めます。
+        /// Warning（孤立ラベル・依存アセットのエントリ化）は記録するだけでビルドは続行します。
+        /// </summary>
+        /// <returns>ビルドを続行してよい場合は true、致命的違反があり中断すべき場合は false。</returns>
+        private static bool PassesConventionGate()
+        {
+            var violations = CheckConventions();
+            if (violations.Count == 0)
+            {
+                return true;
+            }
+
+            // Warning は中断しないが、見落とさないようログには必ず残す。
+            foreach (var warning in violations.Where(violation => !violation.IsError))
+            {
+                Debug.LogWarning(string.Format(ConventionWarningMessageFormat, warning.Message));
+            }
+
+            var errorMessages = violations
+                .Where(violation => violation.IsError)
+                .Select(violation => $"  - {violation.Message}")
+                .ToList();
+            if (errorMessages.Count == 0)
+            {
+                return true;
+            }
+
+            Debug.LogError(string.Format(ConventionGateFailedMessageFormat, string.Join("\n", errorMessages)));
+            return false;
         }
 
         // --- Internal helpers ---

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultViolation.cs
@@ -19,5 +19,11 @@ namespace UniLab.AssetVault.Editor
 
         /// <summary>違反内容の説明（対象アドレス・アセットパス等を含む）です。</summary>
         public string Message { get; }
+
+        /// <summary>
+        /// ビルドを止めるべき致命的違反かどうかです（true なら Error 相当）。
+        /// 重複アドレスは実行時ロードを壊すため Error 扱いとし、Dashboard 表示・ビルド前ゲートの双方がこの判定を共有します。
+        /// </summary>
+        public bool IsError => ViolationType == AssetVaultViolationType.DuplicateAddress;
     }
 }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultWindow.cs
@@ -19,6 +19,9 @@ namespace UniLab.AssetVault.Editor
         private const float SectionSpacing = 8f;
         private const float LabelWidth = 120f;
 
+        // 日本語の利用ガイド。blob/HEAD はデフォルトブランチに自動解決されるため、ブランチ名のハードコードを避けられる。
+        private const string DocumentationUrl = "https://github.com/MasaKoha/UniLab/blob/HEAD/docs/asset-vault-usage.md";
+
         private AssetVaultStatus _status;
         private bool _statusLoaded;
         private IReadOnlyList<AssetVaultViolation> _violations;
@@ -42,6 +45,8 @@ namespace UniLab.AssetVault.Editor
         {
             _scrollPosition = EditorGUILayout.BeginScrollView(_scrollPosition);
 
+            DrawDocumentationSection();
+            EditorGUILayout.Space(SectionSpacing);
             DrawSetupSection();
             EditorGUILayout.Space(SectionSpacing);
             DrawBuildSection();
@@ -55,12 +60,24 @@ namespace UniLab.AssetVault.Editor
             EditorGUILayout.EndScrollView();
         }
 
+        private void DrawDocumentationSection()
+        {
+            DrawHeader("Documentation");
+            // UI は英語だが詳細な日本語ガイドへ即アクセスできるようにする（フォントアトラス対策で日本語は docs に集約しているため）。
+            if (DrawActionButton(
+                "Open Usage Guide (JP)",
+                "Open the Japanese AssetVault usage guide (docs/asset-vault-usage.md) on GitHub."))
+            {
+                Application.OpenURL(DocumentationUrl);
+            }
+        }
+
         private void DrawSetupSection()
         {
             DrawHeader("Setup");
             if (DrawActionButton(
                 "Open Setup Settings",
-                "設定アセット (AssetVaultSetupSettings) を開きます。Local/Remote フォルダの指定と Sync AssetResource はこの Inspector で行います。"))
+                "Open AssetVaultSetupSettings. Configure Local/Remote folders and run Sync AssetResource from its Inspector."))
             {
                 AssetVaultEditorOperations.OpenSetupSettings();
             }
@@ -71,7 +88,7 @@ namespace UniLab.AssetVault.Editor
             DrawHeader("Build");
             if (DrawActionButton(
                 "New Build",
-                "Addressables を新規フルビルドします。初回、またはグループ構成・規約を変更したときに実行します（content state を作り直します）。"))
+                "Full Addressables build. Run on first setup or after group/convention changes (rebuilds content state). Aborts if fatal convention violations (e.g. duplicate addresses) exist."))
             {
                 AssetVaultEditorOperations.BuildNew();
                 RefreshStatus();
@@ -82,7 +99,7 @@ namespace UniLab.AssetVault.Editor
             {
                 if (DrawActionButton(
                     "Content Update (Diff)",
-                    "前回の content state からの差分だけをビルドします。配信済みアプリ向けにアセットを追加・更新するときに使います（先に New Build が必要）。"))
+                    "Builds only the diff from the previous content state. Use to add/update assets for a shipped app (requires a prior New Build)."))
                 {
                     AssetVaultEditorOperations.BuildContentUpdate();
                     RefreshStatus();
@@ -91,22 +108,22 @@ namespace UniLab.AssetVault.Editor
 
             if (!canBuildContentUpdate)
             {
-                EditorGUILayout.HelpBox("content state file が見つかりません。先に New Build を実行してください。", MessageType.None);
+                EditorGUILayout.HelpBox("content state file not found. Run New Build first.", MessageType.None);
             }
         }
 
         private void DrawDebugOverrideSection()
         {
             DrawHeader("Debug Override");
+            // 常時表示テキストは ASCII に限定する（Editor フォントアトラス溢れ回避）。日本語の詳細は docs/asset-vault-usage.md 参照。
             EditorGUILayout.HelpBox(
-                "選択した環境プリセットの BaseUrl で AssetVaultRuntime.BaseUrl を上書きします（ContentPath=版は version.json 解決に任せる）。"
-                + "Editor Play と development ビルドで適用され、release では無効です。"
-                + "有効化・プリセット選択は UI からは行えません（AssetVaultDebugEnvironmentSettings.Activate / Deactivate をコードから呼ぶ）。",
+                "Overrides AssetVaultRuntime.BaseUrl with the preset BaseUrl (development builds only). "
+                + "Enable via Activate / Deactivate from code.",
                 MessageType.Info);
 
             if (DrawActionButton(
                 "Edit Presets",
-                "環境プリセット (表示名・BaseUrl) を編集する設定アセットを選択して Inspector に表示します。"))
+                "Select the settings asset to edit environment presets (display name / BaseUrl) in the Inspector."))
             {
                 Selection.activeObject = AssetVaultDebugEnvironmentSettings.GetOrCreate();
             }
@@ -117,7 +134,7 @@ namespace UniLab.AssetVault.Editor
             DrawHeader("Status");
             if (DrawActionButton(
                 "Refresh",
-                "現在の Addressables 構成 (RemoteLoadPath・Local/Remote グループ数・AssetResource フォルダ有無) を再取得します。"))
+                "Re-fetch the current Addressables configuration (RemoteLoadPath, Local/Remote group counts, AssetResource folder)."))
             {
                 RefreshStatus();
             }
@@ -138,8 +155,8 @@ namespace UniLab.AssetVault.Editor
                 EditorGUILayout.LabelField("RemoteLoadPath", _status.RemoteLoadPath);
                 EditorGUILayout.LabelField("Local Groups", _status.LocalGroupCount.ToString());
                 EditorGUILayout.LabelField("Remote Groups", _status.RemoteGroupCount.ToString());
-                EditorGUILayout.LabelField("Local Folder", string.IsNullOrEmpty(_status.LocalFolderPath) ? "未設定" : _status.LocalFolderPath);
-                EditorGUILayout.LabelField("Remote Folder", string.IsNullOrEmpty(_status.RemoteFolderPath) ? "未設定（任意）" : _status.RemoteFolderPath);
+                EditorGUILayout.LabelField("Local Folder", string.IsNullOrEmpty(_status.LocalFolderPath) ? "Not set" : _status.LocalFolderPath);
+                EditorGUILayout.LabelField("Remote Folder", string.IsNullOrEmpty(_status.RemoteFolderPath) ? "Not set (optional)" : _status.RemoteFolderPath);
             }
         }
 
@@ -148,7 +165,7 @@ namespace UniLab.AssetVault.Editor
             DrawHeader("Conventions");
             if (DrawActionButton(
                 "Check Conventions",
-                "管理グループの規約違反（重複アドレス・孤立ラベル・依存アセットのエントリ化）を検査します。Addressables 標準の Analyze を補う、AssetVault 規約の健全性チェックです。"))
+                "Check management groups for convention violations (duplicate address / orphan label / dependency registered as entry). Complements Addressables Analyze with AssetVault-specific checks."))
             {
                 _violations = AssetVaultEditorOperations.CheckConventions();
                 _violationsChecked = true;
@@ -162,23 +179,17 @@ namespace UniLab.AssetVault.Editor
 
             if (_violations.Count == 0)
             {
-                EditorGUILayout.HelpBox("規約違反は見つかりませんでした。", MessageType.Info);
+                EditorGUILayout.HelpBox("No convention violations found.", MessageType.Info);
                 return;
             }
 
-            EditorGUILayout.LabelField($"{_violations.Count} 件の規約違反", EditorStyles.miniBoldLabel);
+            EditorGUILayout.LabelField($"{_violations.Count} convention violation(s)", EditorStyles.miniBoldLabel);
             foreach (var violation in _violations)
             {
-                EditorGUILayout.HelpBox($"[{violation.ViolationType}] {violation.Message}", ToMessageType(violation.ViolationType));
+                // 重大度は AssetVaultViolation.IsError に一元化されており、ビルド前ゲートと同じ判定を使う。
+                var messageType = violation.IsError ? MessageType.Error : MessageType.Warning;
+                EditorGUILayout.HelpBox($"[{violation.ViolationType}] {violation.Message}", messageType);
             }
-        }
-
-        // DuplicateAddress は実行時ロードを壊す致命傷のため Error、それ以外（孤立ラベル・依存エントリ化）は是正推奨の Warning として表示する。
-        private static MessageType ToMessageType(AssetVaultViolationType violationType)
-        {
-            return violationType == AssetVaultViolationType.DuplicateAddress
-                ? MessageType.Error
-                : MessageType.Warning;
         }
 
         private void RefreshStatus()
@@ -194,14 +205,14 @@ namespace UniLab.AssetVault.Editor
         }
 
         /// <summary>
-        /// 操作ボタンと、その下に折り返し表示する説明文を描画します。説明はホバー時のツールチップにも使います。
+        /// 操作ボタンを描画します。説明はホバー時のツールチップで示します。
+        /// 注意: 説明文を常時ラベル表示していたが、Unity の Editor 動的フォントアトラスが大量の日本語グリフで溢れ、
+        /// ウィンドウ下部の文字が欠ける問題が出たため、同時描画するグリフ数を抑える目的でツールチップのみに変更した。
         /// </summary>
         /// <returns>ボタンが押された場合は true。</returns>
         private static bool DrawActionButton(string label, string description)
         {
-            var clicked = GUILayout.Button(new GUIContent(label, description));
-            EditorGUILayout.LabelField(description, EditorStyles.wordWrappedMiniLabel);
-            return clicked;
+            return GUILayout.Button(new GUIContent(label, description));
         }
 
         /// <summary>

--- a/docs/asset-vault-usage.md
+++ b/docs/asset-vault-usage.md
@@ -401,6 +401,35 @@ _prefab = await _assetVault.LoadAssetAsync<GameObject>(this, key, ct);
 
 ---
 
+## 8. Editor: Asset Vault Dashboard（操作一覧）
+
+`UniLab/AssetVault/Dashboard` を開くと、Addressables 構成の確認・ビルド・規約チェックをまとめて行える。
+
+> 注: Dashboard の **UI 表示テキストは英語**にしている。Unity 6.5 の Editor 動的フォントアトラスが大量の日本語グリフで溢れ、ウィンドウ下部の文字が欠ける不具合があるため、常時描画テキスト・ツールチップ・規約メッセージは ASCII に統一した。各操作の日本語説明はこの節で管理する。
+
+| セクション / ボタン | 日本語の説明 |
+|---|---|
+| **Setup → Open Setup Settings** | 設定アセット `AssetVaultSetupSettings` を開く。Local/Remote フォルダの指定と Sync AssetResource はその Inspector で行う。 |
+| **Build → New Build** | Addressables を新規フルビルド（content state を作り直す）。初回、またはグループ構成・規約を変更したときに実行する。**重複アドレス等の致命的な規約違反があるとビルドは中断**される（後述のビルド前ゲート）。 |
+| **Build → Content Update (Diff)** | 前回の content state からの差分だけをビルドする。配信済みアプリ向けにアセットを追加・更新するときに使う（先に New Build が必要）。 |
+| **Debug Override** | 環境プリセットの BaseUrl で `AssetVaultRuntime.BaseUrl` を上書きする（development ビルドのみ有効、release では無効）。有効化・プリセット選択は UI からは行えず、`AssetVaultDebugEnvironmentSettings.Activate` / `Deactivate` をコードから呼ぶ。`Edit Presets` でプリセット（表示名・BaseUrl）を編集する設定アセットを開く。 |
+| **Status → Refresh** | 現在の Addressables 構成（RemoteLoadPath・Local/Remote グループ数・AssetResource フォルダ有無）を再取得して表示する。 |
+| **Conventions → Check Conventions** | 管理グループの規約違反（重複アドレス・孤立ラベル・依存アセットのエントリ化）を検査する。Addressables 標準の Analyze を補う、AssetVault 規約の健全性チェック。 |
+
+### 規約チェックの3種別とビルド前ゲート
+
+`Check Conventions` で検出する違反は3種類。重大度は `AssetVaultViolation.IsError` に一元化され、Dashboard 表示（Error=赤 / Warning=黄）とビルド前ゲートが同じ判定を共有する。
+
+| 違反種別 | 重大度 | 内容と対処 |
+|---|---|---|
+| **DuplicateAddress** | Error | 同一アドレスが複数エントリに付いている。実行時ロードを壊すため**ビルドを中断**する。アドレスの衝突を解消する。 |
+| **OrphanLabel** | Warning | どのエントリも使っていない孤立ラベル（自動登録の入れ替えで残った等）。ビルドは止めないが警告ログを出す。 |
+| **DependencyRegisteredAsEntry** | Warning | 他エントリの依存でもあるアセットが自身もエントリ登録されている。`_` skip フォルダか共有グループ化を検討する（重複バンドル防止）。 |
+
+`New Build` / `Content Update` は実行前に必ずこのチェックを通す。**Error が1件でもあれば中断**し Console に違反一覧を出力、**Warning は記録のみでビルドは続行**する。
+
+---
+
 ## まとめ（チェックリスト）
 
 - [ ] 画面/シーンごとに `CreateScope()` で 1 スコープを作った


### PR DESCRIPTION
- `BuildNew` / `Content Update` の実行前に規約チェックを通すビルド前ゲートを追加。`DuplicateAddress`(Error)があればビルド中断、Warning は記録のみ続行
- 重大度判定を `AssetVaultViolation.IsError` に一元化し、Dashboard 表示とビルドゲートで共有
- Unity 6.5 の Editor フォントアトラス溢れ対策として、Dashboard の常時表示テキスト・ツールチップ・規約メッセージを英語化（CJK ゼロ化）。日本語の詳細は docs/asset-vault-usage.md に集約
- Dashboard に「Open Usage Guide (JP)」ボタンを追加（GitHub の日本語ガイドを開く）