### PR TITLE
feat: AssetVault のテスト・CIゲート・キャッシュ統計可視化・DL UX 部品を追加

### DIFF
--- a/Assets/Editor/Tests/AssetVault/AssetVaultConventionRulesTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultConventionRulesTest.cs
@@ -1,0 +1,163 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UniLab.AssetVault.Editor;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// 規約違反判定の純粋ロジック <see cref="AssetVaultConventionRules"/> の単体テストです。
+    /// Addressables 設定・AssetDatabase に依存しない収集済みデータだけで検証します。
+    /// </summary>
+    public class AssetVaultConventionRulesTest
+    {
+        /// <summary>
+        /// 同一アドレスが複数エントリに付いている場合、DuplicateAddress 違反を1件だけ追加し、対象パスを含むことを検証します。
+        /// </summary>
+        [Test]
+        public void AddDuplicateAddressViolations_DuplicateAddress_AddsSingleViolationWithPaths()
+        {
+            var managedEntries = new List<AssetVaultConventionRules.ManagedEntry>
+            {
+                new AssetVaultConventionRules.ManagedEntry("Icons/coin", "Assets/Local/UI/coin.png"),
+                new AssetVaultConventionRules.ManagedEntry("Icons/coin", "Assets/Local/UI/coin_dup.png"),
+                new AssetVaultConventionRules.ManagedEntry("Icons/gem", "Assets/Local/UI/gem.png"),
+            };
+            var violations = new List<AssetVaultViolation>();
+
+            AssetVaultConventionRules.AddDuplicateAddressViolations(managedEntries, violations);
+
+            Assert.AreEqual(1, violations.Count);
+            Assert.AreEqual(AssetVaultViolationType.DuplicateAddress, violations[0].ViolationType);
+            Assert.That(violations[0].Message, Does.Contain("Icons/coin"));
+            Assert.That(violations[0].Message, Does.Contain("coin.png"));
+            Assert.That(violations[0].Message, Does.Contain("coin_dup.png"));
+        }
+
+        /// <summary>
+        /// アドレスがすべて一意なら違反を追加しないことを検証します。
+        /// </summary>
+        [Test]
+        public void AddDuplicateAddressViolations_AllUnique_AddsNothing()
+        {
+            var managedEntries = new List<AssetVaultConventionRules.ManagedEntry>
+            {
+                new AssetVaultConventionRules.ManagedEntry("Icons/coin", "Assets/Local/UI/coin.png"),
+                new AssetVaultConventionRules.ManagedEntry("Icons/gem", "Assets/Local/UI/gem.png"),
+            };
+            var violations = new List<AssetVaultViolation>();
+
+            AssetVaultConventionRules.AddDuplicateAddressViolations(managedEntries, violations);
+
+            Assert.IsEmpty(violations);
+        }
+
+        /// <summary>
+        /// どのエントリも使っていないラベルだけ OrphanLabel 違反になることを検証します。
+        /// </summary>
+        [Test]
+        public void AddOrphanLabelViolations_UnusedLabels_AddsViolationsForUnusedOnly()
+        {
+            var allLabels = new[] { "Icons", "Characters", "Stage" };
+            var usedLabels = new HashSet<string> { "Icons" };
+            var violations = new List<AssetVaultViolation>();
+
+            AssetVaultConventionRules.AddOrphanLabelViolations(allLabels, usedLabels, violations);
+
+            Assert.AreEqual(2, violations.Count);
+            Assert.IsTrue(violations.TrueForAll(violation => violation.ViolationType == AssetVaultViolationType.OrphanLabel));
+            Assert.That(violations[0].Message, Does.Contain("Characters"));
+            Assert.That(violations[1].Message, Does.Contain("Stage"));
+        }
+
+        /// <summary>
+        /// すべてのラベルがいずれかのエントリに使われていれば違反を追加しないことを検証します。
+        /// </summary>
+        [Test]
+        public void AddOrphanLabelViolations_AllUsed_AddsNothing()
+        {
+            var allLabels = new[] { "Icons", "Characters" };
+            var usedLabels = new HashSet<string> { "Icons", "Characters" };
+            var violations = new List<AssetVaultViolation>();
+
+            AssetVaultConventionRules.AddOrphanLabelViolations(allLabels, usedLabels, violations);
+
+            Assert.IsEmpty(violations);
+        }
+
+        /// <summary>
+        /// 別の管理エントリの直接依存にもなっている管理アセットが抽出されることを検証します。
+        /// </summary>
+        [Test]
+        public void CollectEntriesReferencedAsDependency_DependencyIsManaged_ReturnsThatPath()
+        {
+            var entriesWithDependencies = new List<(string assetPath, IReadOnlyList<string> directDependencies)>
+            {
+                ("Assets/Local/Characters/hero.prefab", new[] { "Assets/Local/Shared/body.mat" }),
+                ("Assets/Local/Shared/body.mat", new string[0]),
+            };
+            var managedPaths = new HashSet<string>
+            {
+                "Assets/Local/Characters/hero.prefab",
+                "Assets/Local/Shared/body.mat",
+            };
+
+            var referenced = AssetVaultConventionRules.CollectEntriesReferencedAsDependency(entriesWithDependencies, managedPaths);
+
+            Assert.AreEqual(1, referenced.Count);
+            Assert.IsTrue(referenced.Contains("Assets/Local/Shared/body.mat"));
+        }
+
+        /// <summary>
+        /// 依存先が管理対象外（未登録の依存）なら抽出しないことを検証します。
+        /// </summary>
+        [Test]
+        public void CollectEntriesReferencedAsDependency_DependencyNotManaged_ReturnsEmpty()
+        {
+            var entriesWithDependencies = new List<(string assetPath, IReadOnlyList<string> directDependencies)>
+            {
+                ("Assets/Local/Characters/hero.prefab", new[] { "Assets/Local/Characters/_src/hero.anim" }),
+            };
+            var managedPaths = new HashSet<string> { "Assets/Local/Characters/hero.prefab" };
+
+            var referenced = AssetVaultConventionRules.CollectEntriesReferencedAsDependency(entriesWithDependencies, managedPaths);
+
+            Assert.IsEmpty(referenced);
+        }
+
+        /// <summary>
+        /// 自分自身を依存に含む（GetDependencies が自パスを返す）ケースを除外することを検証します。
+        /// </summary>
+        [Test]
+        public void CollectEntriesReferencedAsDependency_SelfDependency_Ignored()
+        {
+            var entriesWithDependencies = new List<(string assetPath, IReadOnlyList<string> directDependencies)>
+            {
+                ("Assets/Local/Characters/hero.prefab", new[] { "Assets/Local/Characters/hero.prefab" }),
+            };
+            var managedPaths = new HashSet<string> { "Assets/Local/Characters/hero.prefab" };
+
+            var referenced = AssetVaultConventionRules.CollectEntriesReferencedAsDependency(entriesWithDependencies, managedPaths);
+
+            Assert.IsEmpty(referenced);
+        }
+
+        /// <summary>
+        /// 抽出済みの依存パスごとに DependencyRegisteredAsEntry 違反を追加することを検証します。
+        /// </summary>
+        [Test]
+        public void AddDependencyEntryViolations_AddsViolationPerPath()
+        {
+            var referencedAsDependency = new HashSet<string>
+            {
+                "Assets/Local/Shared/body.mat",
+            };
+            var violations = new List<AssetVaultViolation>();
+
+            AssetVaultConventionRules.AddDependencyEntryViolations(referencedAsDependency, violations);
+
+            Assert.AreEqual(1, violations.Count);
+            Assert.AreEqual(AssetVaultViolationType.DependencyRegisteredAsEntry, violations[0].ViolationType);
+            Assert.That(violations[0].Message, Does.Contain("body.mat"));
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultConventionRulesTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultConventionRulesTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9a80b2b8fe4694b9aa52690424810848

--- a/Assets/Editor/Tests/AssetVault/AssetVaultViolationTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultViolationTest.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using UniLab.AssetVault.Editor;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// <see cref="AssetVaultViolation"/> の重大度判定（IsError）の単体テストです。
+    /// この判定は Dashboard 表示色とビルド前ゲートの中断可否を兼ねるため、種別ごとに固定して回帰を防ぎます。
+    /// </summary>
+    public class AssetVaultViolationTest
+    {
+        /// <summary>
+        /// 重複アドレスは実行時ロードを壊す致命傷のため Error（IsError = true）であることを検証します。
+        /// </summary>
+        [Test]
+        public void IsError_DuplicateAddress_IsTrue()
+        {
+            var violation = new AssetVaultViolation(AssetVaultViolationType.DuplicateAddress, "message");
+
+            Assert.IsTrue(violation.IsError);
+        }
+
+        /// <summary>
+        /// 孤立ラベルは是正推奨だがビルドは止めない Warning（IsError = false）であることを検証します。
+        /// </summary>
+        [Test]
+        public void IsError_OrphanLabel_IsFalse()
+        {
+            var violation = new AssetVaultViolation(AssetVaultViolationType.OrphanLabel, "message");
+
+            Assert.IsFalse(violation.IsError);
+        }
+
+        /// <summary>
+        /// 依存アセットのエントリ化も Warning（IsError = false）であることを検証します。
+        /// </summary>
+        [Test]
+        public void IsError_DependencyRegisteredAsEntry_IsFalse()
+        {
+            var violation = new AssetVaultViolation(AssetVaultViolationType.DependencyRegisteredAsEntry, "message");
+
+            Assert.IsFalse(violation.IsError);
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultViolationTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultViolationTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 59100195d001e48b889d31432434e3f5

--- a/Assets/UniLab/AssetVault/AssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCache.cs
@@ -30,6 +30,11 @@ namespace UniLab.AssetVault
             // default(struct) は TTL=0/Capacity=0 になるため、未指定は Default を採用する。
             _settings = settings.TtlSeconds <= 0f && settings.Capacity <= 0 ? AssetVaultCacheSettings.Default : settings;
             _timeProvider = timeProvider ?? (() => Time.realtimeSinceStartup);
+
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            // Editor のデバッグ表示から統計を読めるよう、生成時に自己登録する（デバッグ専用）。
+            AssetVaultCacheStatsRegistry.Register(this);
+#endif
         }
 
         /// <inheritdoc />
@@ -142,6 +147,11 @@ namespace UniLab.AssetVault
         /// </summary>
         public void Dispose()
         {
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+            // 自己登録した分を解除する（デバッグ専用）。
+            AssetVaultCacheStatsRegistry.Unregister(this);
+#endif
+
             // pin 参照は破棄するエントリと一緒に解放されるため、保持リストはクリアするだけでよい。
             _prewarmed.Clear();
 

--- a/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs
@@ -1,0 +1,52 @@
+#if UNITY_EDITOR || DEVELOPMENT_BUILD
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 実行中の <see cref="IAssetVaultCache"/> を自己登録させ、Editor のデバッグ表示から参照できるようにする静的レジストリです。
+    /// Runtime asmdef に置くことで Editor/Debug を参照せずに済ませています。デバッグ専用のためリリースビルドには含めません。
+    /// </summary>
+    public static class AssetVaultCacheStatsRegistry
+    {
+        // 複数生成は想定しないため、最後に登録された cache のみを保持する。
+        private static IAssetVaultCache _cache;
+
+        /// <summary>現在 cache が登録されているかどうかを返します。</summary>
+        public static bool HasCache => _cache != null;
+
+        /// <summary>
+        /// cache を現在アクティブなものとして登録します。<see cref="AssetVaultCache"/> のコンストラクタから呼ばれます。
+        /// </summary>
+        public static void Register(IAssetVaultCache cache)
+        {
+            _cache = cache;
+        }
+
+        /// <summary>
+        /// cache の登録を解除します。保持中のものと同一の場合のみクリアします（後発の cache を誤って消さないため）。
+        /// <see cref="AssetVaultCache.Dispose"/> から呼ばれます。
+        /// </summary>
+        public static void Unregister(IAssetVaultCache cache)
+        {
+            if (ReferenceEquals(_cache, cache))
+            {
+                _cache = null;
+            }
+        }
+
+        /// <summary>
+        /// 登録中の cache から統計スナップショットを取得します。未登録の場合は false を返します。
+        /// </summary>
+        public static bool TryGetStats(out AssetVaultCacheStats stats)
+        {
+            if (_cache == null)
+            {
+                stats = default;
+                return false;
+            }
+
+            stats = _cache.GetStats();
+            return true;
+        }
+    }
+}
+#endif

--- a/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e47c4ccd724244efb8f454bdd480bc16

--- a/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// Remote アセットの事前ダウンロードを「サイズ確認 → ユーザー確認 → リトライ付き DL → 進捗通知」まで一括で面倒を見る再利用部品です。
+    /// IAssetVaultService の薄いラッパーとして振る舞い、アプリ側はラベルと確認ダイアログだけ渡せば済むようにします。
+    /// </summary>
+    public sealed class AssetVaultDownloadController
+    {
+        // 指数バックオフの初期遅延（秒）。一時的なネットワーク断からの自動復帰を狙い、即時リトライで相手を叩かないための間隔。
+        private const float InitialRetryDelaySeconds = 0.5f;
+
+        // 指数バックオフの上限遅延（秒）。リトライ間隔が無制限に伸びてユーザーを待たせ続けるのを防ぐためのキャップ。
+        private const float MaxRetryDelaySeconds = 8f;
+
+        private readonly IAssetVaultService _assetVaultService;
+
+        /// <summary>
+        /// ダウンロード対象の vault service を注入して controller を作成します。実プロジェクトでは VContainer 等で注入します。
+        /// </summary>
+        public AssetVaultDownloadController(IAssetVaultService assetVaultService)
+        {
+            _assetVaultService = assetVaultService;
+        }
+
+        /// <summary>
+        /// DownloadAsync 実行中の依存関係ダウンロード進捗を通知します。service のストリームをそのまま委譲します。
+        /// </summary>
+        public Observable<DownloadProgress> OnProgress => _assetVaultService.OnDownloadProgress;
+
+        /// <summary>
+        /// 指定 label の未取得分を、サイズ確認・ユーザー確認・リトライを挟んでダウンロードします。
+        /// confirmAsync が null の場合は確認なしで即ダウンロードします。OperationCanceledException は正常系として呼び出し側へ素通しします。
+        /// </summary>
+        /// <param name="labels">ダウンロード対象のラベル群。</param>
+        /// <param name="confirmAsync">サイズ（バイト）を受け取り、ダウンロード続行可否を返す確認処理。null なら確認をスキップ。</param>
+        /// <param name="maxRetryCount">DL 失敗時の最大リトライ回数。0 ならリトライしない。</param>
+        /// <param name="cancellationToken">キャンセル用トークン。</param>
+        public async UniTask<AssetVaultDownloadResult> EnsureDownloadedAsync(
+            IReadOnlyList<string> labels,
+            Func<long, UniTask<bool>> confirmAsync,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            // --- 1. サイズ確認。未取得分が無ければ通信も確認も不要。 ---
+            var downloadSizeBytes = await _assetVaultService.GetDownloadSizeAsync(labels, cancellationToken);
+            if (downloadSizeBytes <= 0)
+            {
+                return AssetVaultDownloadResult.NothingToDownload;
+            }
+
+            // --- 2. ユーザー確認。拒否されたらダウンロードしない。 ---
+            if (confirmAsync != null)
+            {
+                var confirmed = await confirmAsync(downloadSizeBytes);
+                if (!confirmed)
+                {
+                    return AssetVaultDownloadResult.CanceledByUser;
+                }
+            }
+
+            // --- 3. リトライ付きダウンロード。 ---
+            return await DownloadWithRetryAsync(labels, maxRetryCount, cancellationToken);
+        }
+
+        /// <summary>
+        /// DownloadAsync を最大 maxRetryCount 回まで指数バックオフでリトライします。キャンセルは再 throw します。
+        /// </summary>
+        private async UniTask<AssetVaultDownloadResult> DownloadWithRetryAsync(
+            IReadOnlyList<string> labels,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            AssetVaultException lastException = null;
+
+            for (var attempt = 0; attempt <= maxRetryCount; attempt++)
+            {
+                try
+                {
+                    await _assetVaultService.DownloadAsync(labels, cancellationToken);
+                    return AssetVaultDownloadResult.Completed;
+                }
+                catch (AssetVaultException exception)
+                {
+                    // ロード/通信由来の再試行可能エラー。最後の試行なら抜けてログ＋Failed へ。
+                    lastException = exception;
+                    if (attempt >= maxRetryCount)
+                    {
+                        break;
+                    }
+
+                    await DelayBeforeRetryAsync(attempt, cancellationToken);
+                }
+            }
+
+            // 例外メッセージ・ログは英語、コメント/summary は日本語の方針に従う。
+            Debug.LogError($"[AssetVault] download failed after {maxRetryCount + 1} attempt(s). {lastException}");
+            return AssetVaultDownloadResult.Failed;
+        }
+
+        /// <summary>
+        /// リトライ前に指数バックオフで待機します。連続失敗時に間隔を伸ばし、相手側の一時的な逼迫からの復帰余地を作ります。
+        /// </summary>
+        private static UniTask DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
+        {
+            // 0.5s, 1s, 2s, 4s... と倍々で伸ばし、MaxRetryDelaySeconds で頭打ちにする。
+            var delaySeconds = Mathf.Min(InitialRetryDelaySeconds * Mathf.Pow(2f, attempt), MaxRetryDelaySeconds);
+            return UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4ef3db952c2b749279c4da3f3f94735c

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs
@@ -1,0 +1,76 @@
+using UnityEditor;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// Play 中の <see cref="IAssetVaultCache"/> の占有状況（<see cref="AssetVaultCacheStats"/>）を Editor 上で可視化するウィンドウです。
+    /// 実行中の cache は <see cref="AssetVaultCacheStatsRegistry"/> 経由で取得します。
+    /// </summary>
+    public sealed class AssetVaultCacheStatsWindow : EditorWindow
+    {
+        private const string WindowMenuPath = "UniLab/AssetVault/Cache Stats";
+        private const string WindowTitle = "AssetVault Cache Stats";
+        private const float LabelWidth = 200f;
+
+        [MenuItem(WindowMenuPath)]
+        private static void Open()
+        {
+            var window = GetWindow<AssetVaultCacheStatsWindow>();
+            window.titleContent = new(WindowTitle);
+            window.Show();
+        }
+
+        private void OnGUI()
+        {
+            if (!EditorApplication.isPlaying)
+            {
+                EditorGUILayout.HelpBox("Enter Play Mode and ensure a cache is constructed.", MessageType.Info);
+                return;
+            }
+
+            if (!AssetVaultCacheStatsRegistry.TryGetStats(out var stats))
+            {
+                EditorGUILayout.HelpBox("No AssetVaultCache is registered. Construct a cache to see stats.", MessageType.Warning);
+                return;
+            }
+
+            using (new LabelWidthScope(LabelWidth))
+            {
+                EditorGUILayout.LabelField("Entry Count", stats.EntryCount.ToString());
+                EditorGUILayout.LabelField("Referenced Entry Count", stats.ReferencedEntryCount.ToString());
+                EditorGUILayout.LabelField("Pinned Entry Count", stats.PinnedEntryCount.ToString());
+                EditorGUILayout.LabelField("Unreferenced Entry Count", stats.UnreferencedEntryCount.ToString());
+                EditorGUILayout.LabelField("Total Reference Count", stats.TotalReferenceCount.ToString());
+            }
+        }
+
+        private void Update()
+        {
+            // Play 中は値が変化するため再描画する。GUI 操作が無いと OnGUI は呼ばれないため明示的に Repaint する。
+            if (EditorApplication.isPlaying)
+            {
+                Repaint();
+            }
+        }
+
+        /// <summary>
+        /// IMGUI の EditorGUIUtility.labelWidth を一時的に変更し、Dispose で元に戻すスコープです。
+        /// </summary>
+        private readonly struct LabelWidthScope : System.IDisposable
+        {
+            private readonly float _previousLabelWidth;
+
+            public LabelWidthScope(float labelWidth)
+            {
+                _previousLabelWidth = EditorGUIUtility.labelWidth;
+                EditorGUIUtility.labelWidth = labelWidth;
+            }
+
+            public void Dispose()
+            {
+                EditorGUIUtility.labelWidth = _previousLabelWidth;
+            }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0e6fdee6e63c24ebe833dafa7637233d

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultCiBuild.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultCiBuild.cs
@@ -1,0 +1,80 @@
+using System;
+using UnityEditor;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// CI / batchmode から Addressables ビルドを実行するためのエントリポイントです。
+    /// 実体は <see cref="AssetVaultEditorOperations"/> に委譲し、
+    /// ビルド結果を終了コードへ変換することで CI のパス/フェイルを判定可能にします。
+    /// 新規ビルドの呼び出し例:
+    /// unity -batchmode -quit -executeMethod UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildNewForCi
+    /// content update の呼び出し例:
+    /// unity -batchmode -quit -executeMethod UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildContentUpdateForCi
+    /// </summary>
+    public static class AssetVaultCiBuild
+    {
+        /// <summary>
+        /// 新規 Addressables player content をビルドし、結果を終了コードへ変換します。
+        /// 成功時は exit 0、規約違反やビルド失敗時は exit 1 で CI を確実に落とします。
+        /// CI からは次のように呼び出します:
+        /// unity -batchmode -quit -executeMethod UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildNewForCi
+        /// </summary>
+        public static void BuildNewForCi()
+        {
+            Debug.Log("AssetVault CI: new build started.");
+            try
+            {
+                var succeeded = AssetVaultEditorOperations.BuildNew();
+                // ビルド本体は委譲先が担い、ここは結果を終了コードへ変換するだけの薄い層に留める。
+                ExitByResult(succeeded, "new build");
+            }
+            catch (Exception exception)
+            {
+                // batchmode で例外が握り潰されると CI が緑のまま通過してしまうため、必ず exit 1 で落とす
+                Debug.LogError($"AssetVault CI: new build threw an exception. {exception}");
+                EditorApplication.Exit(1);
+            }
+        }
+
+        /// <summary>
+        /// 前回の content state file から Addressables content update をビルドし、結果を終了コードへ変換します。
+        /// 成功時は exit 0、規約違反やビルド失敗時は exit 1 で CI を確実に落とします。
+        /// CI からは次のように呼び出します:
+        /// unity -batchmode -quit -executeMethod UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildContentUpdateForCi
+        /// </summary>
+        public static void BuildContentUpdateForCi()
+        {
+            Debug.Log("AssetVault CI: content update build started.");
+            try
+            {
+                var succeeded = AssetVaultEditorOperations.BuildContentUpdate();
+                // ビルド本体は委譲先が担い、ここは結果を終了コードへ変換するだけの薄い層に留める。
+                ExitByResult(succeeded, "content update build");
+            }
+            catch (Exception exception)
+            {
+                // batchmode で例外が握り潰されると CI が緑のまま通過してしまうため、必ず exit 1 で落とす
+                Debug.LogError($"AssetVault CI: content update build threw an exception. {exception}");
+                EditorApplication.Exit(1);
+            }
+        }
+
+        /// <summary>
+        /// ビルド成否に応じてログ出力と Editor の終了コードを設定する共通処理です。
+        /// </summary>
+        private static void ExitByResult(bool succeeded, string buildLabel)
+        {
+            if (succeeded)
+            {
+                Debug.Log($"AssetVault CI: {buildLabel} succeeded.");
+                EditorApplication.Exit(0);
+                return;
+            }
+
+            Debug.LogError($"AssetVault CI: {buildLabel} failed.");
+            EditorApplication.Exit(1);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultCiBuild.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultCiBuild.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 85f775e0e81c3462784d306f0fd489a8

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionChecker.cs
@@ -7,6 +7,7 @@ namespace UniLab.AssetVault.Editor
 {
     /// <summary>
     /// AssetVault 管理グループ（Local_/Remote_）の規約違反を Addressables 設定から検出します。
+    /// 設定・AssetDatabase からのデータ収集をここで担い、違反判定そのものは純粋ロジックの <see cref="AssetVaultConventionRules"/> に委譲します（テスト容易性のための分離）。
     /// 検出対象: 重複アドレス・孤立ラベル・依存アセットのエントリ化（skip 漏れ候補）。
     /// </summary>
     internal static class AssetVaultConventionChecker
@@ -19,9 +20,21 @@ namespace UniLab.AssetVault.Editor
             var violations = new List<AssetVaultViolation>();
             var managedEntries = CollectManagedEntries(settings);
 
-            AddDuplicateAddressViolations(managedEntries, violations);
-            AddOrphanLabelViolations(settings, violations);
-            AddDependencyEntryViolations(managedEntries, violations);
+            var entryInfos = managedEntries
+                .Select(entry => new AssetVaultConventionRules.ManagedEntry(entry.address, entry.AssetPath))
+                .ToList();
+            AssetVaultConventionRules.AddDuplicateAddressViolations(entryInfos, violations);
+
+            AssetVaultConventionRules.AddOrphanLabelViolations(settings.GetLabels(), CollectUsedLabels(settings), violations);
+
+            var managedPaths = new HashSet<string>(managedEntries.Select(entry => entry.AssetPath));
+            // 直接依存のみを見る（recursive=false）。間接依存は親が同梱するため対象外。GetDependencies は AssetDatabase 依存なのでここで収集する。
+            var entriesWithDependencies = managedEntries
+                .Select(entry => (entry.AssetPath, (IReadOnlyList<string>)AssetDatabase.GetDependencies(entry.AssetPath, false)))
+                .ToList();
+            var referencedAsDependency = AssetVaultConventionRules.CollectEntriesReferencedAsDependency(entriesWithDependencies, managedPaths);
+            AssetVaultConventionRules.AddDependencyEntryViolations(referencedAsDependency, violations);
+
             return violations;
         }
 
@@ -39,39 +52,6 @@ namespace UniLab.AssetVault.Editor
             }
 
             return entries;
-        }
-
-        // 同一アドレスが2件以上の管理エントリに付いている場合に違反とする（実行時ロードが壊れるため）。
-        private static void AddDuplicateAddressViolations(IReadOnlyList<AddressableAssetEntry> managedEntries, List<AssetVaultViolation> violations)
-        {
-            var duplicateGroups = managedEntries
-                .GroupBy(entry => entry.address)
-                .Where(group => group.Count() > 1);
-
-            foreach (var duplicateGroup in duplicateGroups)
-            {
-                var paths = string.Join(", ", duplicateGroup.Select(entry => entry.AssetPath));
-                violations.Add(new AssetVaultViolation(
-                    AssetVaultViolationType.DuplicateAddress,
-                    $"Duplicate address '{duplicateGroup.Key}': {paths}"));
-            }
-        }
-
-        // どのエントリも使っていないラベル（auto 登録の入れ替えで残った孤立ラベル等）を違反とする。
-        private static void AddOrphanLabelViolations(AddressableAssetSettings settings, List<AssetVaultViolation> violations)
-        {
-            var usedLabels = CollectUsedLabels(settings);
-            foreach (var label in settings.GetLabels())
-            {
-                if (usedLabels.Contains(label))
-                {
-                    continue;
-                }
-
-                violations.Add(new AssetVaultViolation(
-                    AssetVaultViolationType.OrphanLabel,
-                    $"Orphan label '{label}' (not used by any entry)"));
-            }
         }
 
         private static HashSet<string> CollectUsedLabels(AddressableAssetSettings settings)
@@ -94,40 +74,6 @@ namespace UniLab.AssetVault.Editor
             }
 
             return usedLabels;
-        }
-
-        // 他の管理エントリの依存でもあるアセットが、自身もエントリ登録されている場合に違反とする。
-        // 単一利用なら "_" skip フォルダへ、共有なら共有グループへ寄せると重複バンドルを防げる。
-        private static void AddDependencyEntryViolations(IReadOnlyList<AddressableAssetEntry> managedEntries, List<AssetVaultViolation> violations)
-        {
-            var managedPaths = new HashSet<string>(managedEntries.Select(entry => entry.AssetPath));
-            var referencedAsDependency = CollectEntriesReferencedAsDependency(managedEntries, managedPaths);
-
-            foreach (var path in referencedAsDependency)
-            {
-                violations.Add(new AssetVaultViolation(
-                    AssetVaultViolationType.DependencyRegisteredAsEntry,
-                    $"Dependency asset is registered as an entry (consider a '_' skip folder or a shared group): {path}"));
-            }
-        }
-
-        private static HashSet<string> CollectEntriesReferencedAsDependency(IReadOnlyList<AddressableAssetEntry> managedEntries, HashSet<string> managedPaths)
-        {
-            var referencedAsDependency = new HashSet<string>();
-            foreach (var entry in managedEntries)
-            {
-                // 直接依存のみを見る（recursive=false）。間接依存は親が同梱するため対象外。
-                var dependencies = AssetDatabase.GetDependencies(entry.AssetPath, false);
-                foreach (var dependency in dependencies)
-                {
-                    if (dependency != entry.AssetPath && managedPaths.Contains(dependency))
-                    {
-                        referencedAsDependency.Add(dependency);
-                    }
-                }
-            }
-
-            return referencedAsDependency;
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionRules.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionRules.cs
@@ -1,0 +1,106 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UniLab.AssetVault.Editor
+{
+    /// <summary>
+    /// 規約違反の判定ロジック本体（純粋関数）。Addressables 設定・AssetDatabase に依存しないため EditMode で単体テストできます。
+    /// 設定からのデータ収集は <see cref="AssetVaultConventionChecker"/> が担い、ここは収集済みデータから違反を導出することだけに専念します。
+    /// </summary>
+    internal static class AssetVaultConventionRules
+    {
+        /// <summary>
+        /// 規約判定に必要な、管理エントリ1件分の最小データです（Addressables 型に依存させないための受け皿）。
+        /// </summary>
+        internal readonly struct ManagedEntry
+        {
+            /// <summary>アドレスとアセットパスを指定して生成します。</summary>
+            public ManagedEntry(string address, string assetPath)
+            {
+                Address = address;
+                AssetPath = assetPath;
+            }
+
+            /// <summary>Addressables アドレス。</summary>
+            public string Address { get; }
+
+            /// <summary>アセットパス。</summary>
+            public string AssetPath { get; }
+        }
+
+        /// <summary>
+        /// 同一アドレスが2件以上の管理エントリに付いている重複を違反として <paramref name="violations"/> に追加します。
+        /// 同一アドレスは実行時ロードを壊すため Error 相当の違反です。
+        /// </summary>
+        internal static void AddDuplicateAddressViolations(IReadOnlyList<ManagedEntry> managedEntries, List<AssetVaultViolation> violations)
+        {
+            var duplicateGroups = managedEntries
+                .GroupBy(entry => entry.Address)
+                .Where(group => group.Count() > 1);
+
+            foreach (var duplicateGroup in duplicateGroups)
+            {
+                var paths = string.Join(", ", duplicateGroup.Select(entry => entry.AssetPath));
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.DuplicateAddress,
+                    $"Duplicate address '{duplicateGroup.Key}': {paths}"));
+            }
+        }
+
+        /// <summary>
+        /// どのエントリも使っていない孤立ラベル（auto 登録の入れ替えで残った等）を違反として追加します。
+        /// </summary>
+        internal static void AddOrphanLabelViolations(IEnumerable<string> allLabels, ICollection<string> usedLabels, List<AssetVaultViolation> violations)
+        {
+            foreach (var label in allLabels)
+            {
+                if (usedLabels.Contains(label))
+                {
+                    continue;
+                }
+
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.OrphanLabel,
+                    $"Orphan label '{label}' (not used by any entry)"));
+            }
+        }
+
+        /// <summary>
+        /// 各管理エントリの直接依存集合から、別の管理エントリの依存にもなっている管理アセットのパスを抽出します。
+        /// （= 起点としても依存としても使われているアセット。重複バンドルの温床。）
+        /// 直接依存のみを見る前提で、間接依存は呼び出し側で渡さないこと（親が同梱するため対象外）。
+        /// </summary>
+        internal static HashSet<string> CollectEntriesReferencedAsDependency(
+            IReadOnlyList<(string assetPath, IReadOnlyList<string> directDependencies)> entriesWithDependencies,
+            ISet<string> managedPaths)
+        {
+            var referencedAsDependency = new HashSet<string>();
+            foreach (var entry in entriesWithDependencies)
+            {
+                foreach (var dependency in entry.directDependencies)
+                {
+                    if (dependency != entry.assetPath && managedPaths.Contains(dependency))
+                    {
+                        referencedAsDependency.Add(dependency);
+                    }
+                }
+            }
+
+            return referencedAsDependency;
+        }
+
+        /// <summary>
+        /// 依存としても参照されている管理アセット群を違反として追加します。
+        /// 単一利用なら "_" skip フォルダへ、共有なら共有グループへ寄せると重複バンドルを防げます。
+        /// </summary>
+        internal static void AddDependencyEntryViolations(IReadOnlyCollection<string> referencedAsDependency, List<AssetVaultViolation> violations)
+        {
+            foreach (var path in referencedAsDependency)
+            {
+                violations.Add(new AssetVaultViolation(
+                    AssetVaultViolationType.DependencyRegisteredAsEntry,
+                    $"Dependency asset is registered as an entry (consider a '_' skip folder or a shared group): {path}"));
+            }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultConventionRules.cs.meta
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultConventionRules.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 03658db7ccb6d4e07a6c932a64fc9f3d

--- a/Assets/UniLab/AssetVault/Model/AssetVaultDownloadResult.cs
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultDownloadResult.cs
@@ -1,0 +1,33 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// EnsureDownloadedAsync の事前ダウンロードフロー（サイズ確認 → ユーザー確認 → リトライ付き DL）の最終結果を表します。
+    /// </summary>
+    public enum AssetVaultDownloadResult
+    {
+        /// <summary>
+        /// 既定値（未設定）。default(AssetVaultDownloadResult) がこの値になります。
+        /// </summary>
+        None = 0,
+
+        /// <summary>
+        /// 未取得分のサイズが 0 以下で、ダウンロードする対象が無かったことを表します。
+        /// </summary>
+        NothingToDownload,
+
+        /// <summary>
+        /// 依存関係のダウンロードが正常に完了したことを表します。
+        /// </summary>
+        Completed,
+
+        /// <summary>
+        /// 確認ダイアログでユーザーがダウンロードを拒否したことを表します。
+        /// </summary>
+        CanceledByUser,
+
+        /// <summary>
+        /// リトライを尽くしてもダウンロードに失敗したことを表します。
+        /// </summary>
+        Failed
+    }
+}

--- a/Assets/UniLab/AssetVault/Model/AssetVaultDownloadResult.cs.meta
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultDownloadResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d1a5993116f86429ca1d78d2ef637acb

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultDownloadSample.cs
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultDownloadSample.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+
+namespace UniLab.AssetVault.Sample
+{
+    /// <summary>
+    /// AssetVaultDownloadController を使い、「進捗購読 → サイズ確認スタブ → リトライ付き事前ダウンロード」を最小構成で示すサンプルです。
+    ///
+    /// 実プロジェクトでの推奨形:
+    ///   - IAssetVaultService と AssetVaultDownloadController は DI（VContainer）で注入する。
+    ///   - confirmAsync には実際の確認ダイアログ（「○○MB ダウンロードします」）を渡す。
+    /// 本サンプルは自己完結のため Service を直接 new し、confirmAsync も常に true を返すスタブにしています。
+    /// </summary>
+    public sealed class AssetVaultDownloadSample : MonoBehaviour
+    {
+        // 配信先の基底 URL。Local 同梱のみで試すなら空でよい（version 解決はスキップされる）。
+        [Header("配信先 BaseUrl（Local のみなら空でよい）")]
+        [SerializeField] private string _baseUrl = "";
+
+        // 事前ダウンロード対象ラベル。Local 同梱のみなら空でよい。
+        [Header("Remote 事前ダウンロード対象ラベル")]
+        [SerializeField] private string[] _preloadLabels = Array.Empty<string>();
+
+        // DL 失敗時の最大リトライ回数。
+        [Header("最大リトライ回数")]
+        [SerializeField] private int _maxRetryCount = 3;
+
+        // 自己完結サンプルのため new。実プロジェクトでは IAssetVaultService をコンストラクタ注入する。
+        private readonly AddressablesAssetVaultService _assetVaultService = new();
+
+        // 進捗購読をまとめて破棄するためのコンテナ（OnDestroy で Dispose）。
+        private readonly CompositeDisposable _compositeDisposable = new();
+
+        // service を包む再利用部品。実プロジェクトでは VContainer で注入する。
+        private AssetVaultDownloadController _downloadController;
+
+        private void Start()
+        {
+            _downloadController = new AssetVaultDownloadController(_assetVaultService);
+
+            // 進捗（0..1）を購読してパーセント表示。DownloadAsync 実行中のみ発火する。
+            _downloadController.OnProgress
+                .Subscribe(progress => Debug.Log($"[AssetVault] download {progress.Ratio:P0}"))
+                .AddTo(_compositeDisposable);
+
+            // destroyCancellationToken を使うので、画面破棄でフローが自動キャンセルされる。
+            RunAsync(destroyCancellationToken).Forget();
+        }
+
+        /// <summary>
+        /// 初期化してから、リトライ付きの事前ダウンロードを実行する一連フロー。
+        /// </summary>
+        private async UniTask RunAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _assetVaultService.InitializeAsync(_baseUrl, cancellationToken);
+
+                var result = await _downloadController.EnsureDownloadedAsync(
+                    _preloadLabels,
+                    ConfirmDownloadAsync,
+                    _maxRetryCount,
+                    cancellationToken);
+
+                Debug.Log($"[AssetVault] ensure download result = {result}");
+            }
+            catch (OperationCanceledException)
+            {
+                // 画面破棄（destroyCancellationToken）などによる正常キャンセル。
+            }
+        }
+
+        /// <summary>
+        /// 確認ダイアログ代わりのスタブ。サイズをログに出し、常に続行（true）を返します。
+        /// 実プロジェクトでは「○○MB ダウンロードしますか？」の UI を出し、ユーザーの選択を返します。
+        /// </summary>
+        private UniTask<bool> ConfirmDownloadAsync(long downloadSizeBytes)
+        {
+            var megaBytes = downloadSizeBytes / (1024f * 1024f);
+            Debug.Log($"[AssetVault] confirm download: {megaBytes:F1} MB");
+            return UniTask.FromResult(true);
+        }
+
+        private void OnDestroy()
+        {
+            // 自己完結のため new した Service（State/進捗ストリーム）と、購読だけを破棄する。
+            _assetVaultService.Dispose();
+            _compositeDisposable.Dispose();
+        }
+    }
+}

--- a/Assets/UniLab/Sample/AssetVault/AssetVaultDownloadSample.cs.meta
+++ b/Assets/UniLab/Sample/AssetVault/AssetVaultDownloadSample.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 832bb81b0f6e7499fa5ea94a44f24101


### PR DESCRIPTION
- test: 規約チェッカーの純粋ロジックを `AssetVaultConventionRules` に抽出し EditMode テスト追加（重複アドレス/孤立ラベル/依存エントリ化の検出・非検出、IsError 重大度）
- feat: `AssetVaultCiBuild`（batchmode 用）。ビルド前規約ゲートで Error 違反時に exit 1
- feat: `AssetVaultCacheStatsRegistry` + `Cache Stats` ウィンドウで Play 中のキャッシュ統計を可視化（ctor 自己登録、UNITY_EDITOR||DEVELOPMENT_BUILD ガード）
- feat: `AssetVaultDownloadController` でサイズ確認→ユーザー確認→リトライ→進捗の事前 DL フローを共通化、サンプル同梱