### PR TITLE
feat: AssetVault のコアテスト・カタログ更新フロー・CI・メモリ可視化を追加

### DIFF
--- a/.github/workflows/addressables-ci.yml
+++ b/.github/workflows/addressables-ci.yml
@@ -1,0 +1,101 @@
+# Addressables CI
+#
+# 目的:
+#   - AssetVault の規約ゲートと EditMode テストを Pull Request 上で自動実行する。
+#   - editmode-tests ジョブで EditMode テストを回し、
+#     convention-gate-build ジョブで規約ゲート付きの Addressables 新規ビルドを実行する。
+#   - 規約ゲートのビルドは buildMethod として
+#     UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildNewForCi を呼び出す。
+#     このメソッドは規約違反・ビルド失敗時に EditorApplication.Exit(1) を行うため、
+#     違反があるとビルドが失敗扱いになり CI が落ちる。
+#
+# 必要な secrets（リポジトリの Settings > Secrets and variables > Actions に設定すること）:
+#   - UNITY_LICENSE : Unity ライセンスファイル(.ulf)の中身。Personal/Professional いずれも必要。
+#   - UNITY_EMAIL   : Unity アカウントのメールアドレス。
+#   - UNITY_PASSWORD: Unity アカウントのパスワード。
+#
+# 使用アクション:
+#   game-ci/unity-test-runner@v4 / game-ci/unity-builder@v4
+#   actions/checkout@v4 / actions/cache@v4 / actions/upload-artifact@v4
+
+name: Addressables CI
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+# 同一ブランチで新しい push があれば実行中のワークフローをキャンセルする
+concurrency:
+  group: addressables-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+  UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+  UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+
+jobs:
+  editmode-tests:
+    name: EditMode Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # Library を OS とアセット/パッケージのハッシュでキャッシュし、import 時間を短縮する
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-editmode-${{ runner.os }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-editmode-${{ runner.os }}-
+            Library-${{ runner.os }}-
+
+      - name: Run EditMode tests
+        uses: game-ci/unity-test-runner@v4
+        with:
+          unityVersion: 6000.5.0f1
+          testMode: EditMode
+          artifactsPath: artifacts/editmode
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: editmode-test-results
+          path: artifacts/editmode
+
+  convention-gate-build:
+    name: Convention Gate Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          lfs: true
+
+      # Library を OS とアセット/パッケージのハッシュでキャッシュし、import 時間を短縮する
+      - name: Cache Library
+        uses: actions/cache@v4
+        with:
+          path: Library
+          key: Library-build-${{ runner.os }}-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            Library-build-${{ runner.os }}-
+            Library-${{ runner.os }}-
+
+      # buildMethod に AssetVaultCiBuild.BuildNewForCi を指定し、規約ゲート付き Addressables ビルドを実行する。
+      # 規約違反時は内部で EditorApplication.Exit(1) するため、このステップが失敗し CI が落ちる。
+      - name: Convention gate Addressables build
+        uses: game-ci/unity-builder@v4
+        with:
+          unityVersion: 6000.5.0f1
+          targetPlatform: StandaloneLinux64
+          buildMethod: UniLab.AssetVault.Editor.AssetVaultCiBuild.BuildNewForCi

--- a/Assets/Editor/Tests/AssetVault/AssetVaultCacheEvictionPolicyTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultCacheEvictionPolicyTest.cs
@@ -1,0 +1,124 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UniLab.AssetVault;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// キャッシュ退避判定の純ロジック <see cref="AssetVaultCacheEvictionPolicy"/> の単体テストです。
+    /// TTL 境界（ちょうど期限）と LRU の選択順・取りすぎ防止という、バグを生みやすい箇所を固定します。
+    /// </summary>
+    public class AssetVaultCacheEvictionPolicyTest
+    {
+        /// <summary>
+        /// 参照中（refCount &gt; 0）のエントリは、TTL を過ぎていても期限切れにしないことを検証します。
+        /// </summary>
+        [Test]
+        public void IsExpired_Referenced_NeverExpires()
+        {
+            var expired = AssetVaultCacheEvictionPolicy.IsExpired(refCount: 1, lastReleaseTime: 0f, now: 100f, ttlSeconds: 10f);
+
+            Assert.IsFalse(expired);
+        }
+
+        /// <summary>
+        /// 未参照で最終解放からちょうど TTL 経過した境界では期限切れ（>= 判定）になることを検証します。
+        /// </summary>
+        [Test]
+        public void IsExpired_UnreferencedExactlyAtTtl_IsExpired()
+        {
+            var expired = AssetVaultCacheEvictionPolicy.IsExpired(refCount: 0, lastReleaseTime: 0f, now: 10f, ttlSeconds: 10f);
+
+            Assert.IsTrue(expired);
+        }
+
+        /// <summary>
+        /// 未参照だが TTL 未満の経過では期限切れにしないことを検証します。
+        /// </summary>
+        [Test]
+        public void IsExpired_UnreferencedBeforeTtl_IsNotExpired()
+        {
+            var expired = AssetVaultCacheEvictionPolicy.IsExpired(refCount: 0, lastReleaseTime: 0f, now: 9.9f, ttlSeconds: 10f);
+
+            Assert.IsFalse(expired);
+        }
+
+        /// <summary>
+        /// 上限以下なら何も解放しないことを検証します。
+        /// </summary>
+        [Test]
+        public void SelectOverCapacityKeys_WithinCapacity_ReturnsEmpty()
+        {
+            var entries = new List<(string key, int refCount, float lastReleaseTime)>
+            {
+                ("a", 0, 1f),
+                ("b", 0, 2f),
+            };
+
+            var keysToReclaim = AssetVaultCacheEvictionPolicy.SelectOverCapacityKeys(entries, capacity: 2);
+
+            Assert.IsEmpty(keysToReclaim);
+        }
+
+        /// <summary>
+        /// capacity &lt;= 0（無制限）なら何も解放しないことを検証します。
+        /// </summary>
+        [Test]
+        public void SelectOverCapacityKeys_UnlimitedCapacity_ReturnsEmpty()
+        {
+            var entries = new List<(string key, int refCount, float lastReleaseTime)>
+            {
+                ("a", 0, 1f),
+                ("b", 0, 2f),
+                ("c", 0, 3f),
+            };
+
+            var keysToReclaim = AssetVaultCacheEvictionPolicy.SelectOverCapacityKeys(entries, capacity: 0);
+
+            Assert.IsEmpty(keysToReclaim);
+        }
+
+        /// <summary>
+        /// 上限超過時、未参照を「最終解放が古い順」に超過分だけ解放し、参照中は対象外であることを検証します。
+        /// </summary>
+        [Test]
+        public void SelectOverCapacityKeys_OverCapacity_ReclaimsOldestUnreferencedFirst()
+        {
+            var entries = new List<(string key, int refCount, float lastReleaseTime)>
+            {
+                ("a", 0, 1f),
+                ("b", 0, 3f),
+                ("referenced", 1, 0f),
+                ("d", 0, 2f),
+            };
+
+            // 4件 → 上限2 なので2件解放。未参照を古い順に並べると a(1) < d(2) < b(3)。参照中 'referenced' は対象外。
+            var keysToReclaim = AssetVaultCacheEvictionPolicy.SelectOverCapacityKeys(entries, capacity: 2);
+
+            Assert.AreEqual(2, keysToReclaim.Count);
+            Assert.AreEqual("a", keysToReclaim[0]);
+            Assert.AreEqual("d", keysToReclaim[1]);
+            CollectionAssert.DoesNotContain(keysToReclaim, "referenced");
+        }
+
+        /// <summary>
+        /// 未参照が超過分に足りない場合は、取れる分だけ解放する（参照中は触らない）ことを検証します。
+        /// </summary>
+        [Test]
+        public void SelectOverCapacityKeys_NotEnoughUnreferenced_ReclaimsAvailableOnly()
+        {
+            var entries = new List<(string key, int refCount, float lastReleaseTime)>
+            {
+                ("a", 1, 0f),
+                ("b", 1, 0f),
+                ("c", 0, 5f),
+            };
+
+            // 3件 → 上限1 なので2件解放したいが、未参照は c のみ。c だけ返す。
+            var keysToReclaim = AssetVaultCacheEvictionPolicy.SelectOverCapacityKeys(entries, capacity: 1);
+
+            Assert.AreEqual(1, keysToReclaim.Count);
+            Assert.AreEqual("c", keysToReclaim[0]);
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultCacheEvictionPolicyTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultCacheEvictionPolicyTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 28d69ac9dd8e14f89a054ca621195639

--- a/Assets/Editor/Tests/AssetVault/AssetVaultRetryPolicyTest.cs
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultRetryPolicyTest.cs
@@ -1,0 +1,35 @@
+using NUnit.Framework;
+using UniLab.AssetVault;
+
+namespace UniLab.Tests.EditMode.AssetVault
+{
+    /// <summary>
+    /// リトライ間隔計算 <see cref="AssetVaultRetryPolicy"/> の単体テストです。
+    /// Download / Update のリトライが共有する指数バックオフの倍増と上限キャップを固定します。
+    /// </summary>
+    public class AssetVaultRetryPolicyTest
+    {
+        /// <summary>
+        /// attempt が増えるごとに 0.5s から倍々（1s, 2s, 4s）で伸びることを検証します。
+        /// </summary>
+        [Test]
+        public void GetBackoffDelaySeconds_DoublesPerAttempt()
+        {
+            Assert.AreEqual(0.5f, AssetVaultRetryPolicy.GetBackoffDelaySeconds(0), 0.0001f);
+            Assert.AreEqual(1f, AssetVaultRetryPolicy.GetBackoffDelaySeconds(1), 0.0001f);
+            Assert.AreEqual(2f, AssetVaultRetryPolicy.GetBackoffDelaySeconds(2), 0.0001f);
+            Assert.AreEqual(4f, AssetVaultRetryPolicy.GetBackoffDelaySeconds(3), 0.0001f);
+        }
+
+        /// <summary>
+        /// 上限（MaxRetryDelaySeconds=8s）に達したらそれ以上伸びず頭打ちになることを検証します。
+        /// </summary>
+        [Test]
+        public void GetBackoffDelaySeconds_CapsAtMax()
+        {
+            Assert.AreEqual(AssetVaultRetryPolicy.MaxRetryDelaySeconds, AssetVaultRetryPolicy.GetBackoffDelaySeconds(4), 0.0001f);
+            Assert.AreEqual(AssetVaultRetryPolicy.MaxRetryDelaySeconds, AssetVaultRetryPolicy.GetBackoffDelaySeconds(5), 0.0001f);
+            Assert.AreEqual(AssetVaultRetryPolicy.MaxRetryDelaySeconds, AssetVaultRetryPolicy.GetBackoffDelaySeconds(10), 0.0001f);
+        }
+    }
+}

--- a/Assets/Editor/Tests/AssetVault/AssetVaultRetryPolicyTest.cs.meta
+++ b/Assets/Editor/Tests/AssetVault/AssetVaultRetryPolicyTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 890df329113c0496c86a265b46705bca

--- a/Assets/UniLab/AssetVault/AssemblyInfo.cs
+++ b/Assets/UniLab/AssetVault/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+using System.Runtime.CompilerServices;
+
+// 退避判定（AssetVaultCacheEvictionPolicy）・リトライ間隔（AssetVaultRetryPolicy）等の internal 純ロジックを EditMode テストから検証できるようにする。
+[assembly: InternalsVisibleTo("AssetVaultTest")]

--- a/Assets/UniLab/AssetVault/AssemblyInfo.cs.meta
+++ b/Assets/UniLab/AssetVault/AssemblyInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d2dea821e9f494a8f8054d9ae727eefb

--- a/Assets/UniLab/AssetVault/AssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCache.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
+using UnityEngine.Profiling;
 using UnityEngine.ResourceManagement.AsyncOperations;
 
 namespace UniLab.AssetVault
@@ -142,6 +143,22 @@ namespace UniLab.AssetVault
             return new AssetVaultCacheStats(_entries.Count, referencedEntryCount, _prewarmed.Count, totalReferenceCount);
         }
 
+        /// <inheritdoc />
+        public long EstimateMemoryBytes()
+        {
+            // ロード済みアセットの実行時メモリ量を Profiler で概算する（厳密値ではなく診断の目安）。GetStats と分けてオンデマンド計算に留める。
+            long totalBytes = 0;
+            foreach (var pair in _entries)
+            {
+                if (pair.Value.Handle.IsValid() && pair.Value.Handle.Result is UnityEngine.Object loadedObject && loadedObject != null)
+                {
+                    totalBytes += Profiler.GetRuntimeMemorySizeLong(loadedObject);
+                }
+            }
+
+            return totalBytes;
+        }
+
         /// <summary>
         /// 全エントリを参照カウントに関わらず解放します。
         /// </summary>
@@ -195,11 +212,12 @@ namespace UniLab.AssetVault
                 return;
             }
 
+            // perf: 期限判定は純ロジックに委譲しつつ、共通バッファを使い回して走査自体はアロケーションフリーに保つ。
             var now = _timeProvider();
             _reclaimBuffer.Clear();
             foreach (var pair in _entries)
             {
-                if (pair.Value.RefCount <= 0 && now - pair.Value.LastReleaseTime >= _settings.TtlSeconds)
+                if (AssetVaultCacheEvictionPolicy.IsExpired(pair.Value.RefCount, pair.Value.LastReleaseTime, now, _settings.TtlSeconds))
                 {
                     _reclaimBuffer.Add(pair.Key);
                 }
@@ -218,25 +236,16 @@ namespace UniLab.AssetVault
                 return;
             }
 
-            // 未参照エントリを「最後に手放した時刻が古い順」に解放して上限まで詰める。
-            _reclaimBuffer.Clear();
+            // 上限超過は稀なので、ここでだけスナップショットを作って LRU 選択を純ロジックに委譲する。
+            var snapshot = new List<(CacheKey key, int refCount, float lastReleaseTime)>(_entries.Count);
             foreach (var pair in _entries)
             {
-                if (pair.Value.RefCount <= 0)
-                {
-                    _reclaimBuffer.Add(pair.Key);
-                }
+                snapshot.Add((pair.Key, pair.Value.RefCount, pair.Value.LastReleaseTime));
             }
 
-            _reclaimBuffer.Sort((left, right) => _entries[left].LastReleaseTime.CompareTo(_entries[right].LastReleaseTime));
-
-            foreach (var cacheKey in _reclaimBuffer)
+            var keysToReclaim = AssetVaultCacheEvictionPolicy.SelectOverCapacityKeys(snapshot, _settings.Capacity);
+            foreach (var cacheKey in keysToReclaim)
             {
-                if (_entries.Count <= _settings.Capacity)
-                {
-                    break;
-                }
-
                 ReleaseEntry(cacheKey, _entries[cacheKey]);
             }
         }

--- a/Assets/UniLab/AssetVault/AssetVaultCacheEvictionPolicy.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheEvictionPolicy.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// <see cref="AssetVaultCache"/> の遅延解放（TTL 期限切れ・LRU 上限超過）の「どれを解放するか」の判定ロジックです。
+    /// Addressables ハンドルに依存しない純関数として切り出し、境界条件（TTL ちょうど・LRU の取りすぎ）を EditMode で単体テストできるようにしています。
+    /// </summary>
+    internal static class AssetVaultCacheEvictionPolicy
+    {
+        /// <summary>
+        /// エントリが TTL 期限切れ（未参照かつ最終解放から TTL 以上経過）かどうかを判定します。
+        /// TtlSeconds &lt;= 0（即時解放）の扱いは呼び出し側の責務で、本メソッドは TTL &gt; 0 前提の経過時間判定だけを行います。
+        /// </summary>
+        internal static bool IsExpired(int refCount, float lastReleaseTime, float now, float ttlSeconds)
+        {
+            return refCount <= 0 && now - lastReleaseTime >= ttlSeconds;
+        }
+
+        /// <summary>
+        /// LRU 上限超過分として解放すべきキーを「未参照のうち最終解放時刻が古い順」に選びます。
+        /// capacity &lt;= 0 は無制限（空を返す）。参照中エントリは解放対象にしません。未参照が足りなければ取れる分だけ返します。
+        /// </summary>
+        internal static List<TKey> SelectOverCapacityKeys<TKey>(
+            IReadOnlyList<(TKey key, int refCount, float lastReleaseTime)> entries,
+            int capacity)
+        {
+            var keysToReclaim = new List<TKey>();
+            if (capacity <= 0 || entries.Count <= capacity)
+            {
+                return keysToReclaim;
+            }
+
+            var unreferencedOldestFirst = entries
+                .Where(entry => entry.refCount <= 0)
+                .OrderBy(entry => entry.lastReleaseTime)
+                .ToList();
+
+            var removableCount = entries.Count - capacity;
+            for (var index = 0; index < removableCount && index < unreferencedOldestFirst.Count; index++)
+            {
+                keysToReclaim.Add(unreferencedOldestFirst[index].key);
+            }
+
+            return keysToReclaim;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultCacheEvictionPolicy.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheEvictionPolicy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4edc2b0027a2547faa62ab643cafe6b9

--- a/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultCacheStatsRegistry.cs
@@ -47,6 +47,35 @@ namespace UniLab.AssetVault
             stats = _cache.GetStats();
             return true;
         }
+
+        /// <summary>
+        /// 登録中の cache のロード済みアセットの概算メモリ量（バイト）を取得します。未登録の場合は false を返します。
+        /// </summary>
+        public static bool TryGetEstimatedMemoryBytes(out long estimatedBytes)
+        {
+            if (_cache == null)
+            {
+                estimatedBytes = 0;
+                return false;
+            }
+
+            estimatedBytes = _cache.EstimateMemoryBytes();
+            return true;
+        }
+
+        /// <summary>
+        /// 登録中の cache に対して Trim（TTL 期限切れ・LRU 超過の未参照エントリの即時解放）を実行します。未登録の場合は false を返します。
+        /// </summary>
+        public static bool TryTrim()
+        {
+            if (_cache == null)
+            {
+                return false;
+            }
+
+            _cache.Trim();
+            return true;
+        }
     }
 }
 #endif

--- a/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
@@ -13,12 +13,6 @@ namespace UniLab.AssetVault
     /// </summary>
     public sealed class AssetVaultDownloadController
     {
-        // 指数バックオフの初期遅延（秒）。一時的なネットワーク断からの自動復帰を狙い、即時リトライで相手を叩かないための間隔。
-        private const float InitialRetryDelaySeconds = 0.5f;
-
-        // 指数バックオフの上限遅延（秒）。リトライ間隔が無制限に伸びてユーザーを待たせ続けるのを防ぐためのキャップ。
-        private const float MaxRetryDelaySeconds = 8f;
-
         private readonly IAssetVaultService _assetVaultService;
 
         /// <summary>
@@ -105,12 +99,11 @@ namespace UniLab.AssetVault
         }
 
         /// <summary>
-        /// リトライ前に指数バックオフで待機します。連続失敗時に間隔を伸ばし、相手側の一時的な逼迫からの復帰余地を作ります。
+        /// リトライ前に指数バックオフで待機します。間隔計算は <see cref="AssetVaultRetryPolicy"/> に集約しています。
         /// </summary>
         private static UniTask DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
         {
-            // 0.5s, 1s, 2s, 4s... と倍々で伸ばし、MaxRetryDelaySeconds で頭打ちにする。
-            var delaySeconds = Mathf.Min(InitialRetryDelaySeconds * Mathf.Pow(2f, attempt), MaxRetryDelaySeconds);
+            var delaySeconds = AssetVaultRetryPolicy.GetBackoffDelaySeconds(attempt);
             return UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
         }
     }

--- a/Assets/UniLab/AssetVault/AssetVaultRetryPolicy.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultRetryPolicy.cs
@@ -1,0 +1,26 @@
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// リトライ時の指数バックオフ間隔を計算する純ロジックです。
+    /// Download / Update のリトライで仕様を共有し、間隔の定義を一箇所に集約します（Addressables/UniTask に依存しないため単体テスト可能）。
+    /// </summary>
+    internal static class AssetVaultRetryPolicy
+    {
+        /// <summary>指数バックオフの初期遅延（秒）。即時リトライで相手を叩かないための最小間隔です。</summary>
+        internal const float InitialRetryDelaySeconds = 0.5f;
+
+        /// <summary>指数バックオフの上限遅延（秒）。間隔が無制限に伸びてユーザーを待たせ続けるのを防ぐキャップです。</summary>
+        internal const float MaxRetryDelaySeconds = 8f;
+
+        /// <summary>
+        /// attempt 回目（0 始まり）のリトライ前に待つ秒数を返します。
+        /// 0.5s, 1s, 2s, 4s… と倍々で伸ばし、<see cref="MaxRetryDelaySeconds"/> で頭打ちにします。
+        /// </summary>
+        internal static float GetBackoffDelaySeconds(int attempt)
+        {
+            return Mathf.Min(InitialRetryDelaySeconds * Mathf.Pow(2f, attempt), MaxRetryDelaySeconds);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultRetryPolicy.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultRetryPolicy.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 7327385e29d434a0fba13572bd169667

--- a/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 「リモート catalog の更新確認 → 差分（指定ラベル）の事前ダウンロード」を一括で面倒を見る再利用部品です。
+    /// catalog 確認は自身がリトライ付きで実行し、ダウンロードフローは AssetVaultDownloadController に委譲します。
+    /// アプリ側は事前 DL したいラベルと確認ダイアログだけ渡せば、更新～事前取得まで済むようにします。
+    /// </summary>
+    public sealed class AssetVaultUpdateController
+    {
+        private readonly IAssetVaultService _assetVaultService;
+        private readonly AssetVaultDownloadController _downloadController;
+
+        /// <summary>
+        /// 対象の vault service を注入して controller を作成します。ダウンロードフロー用の AssetVaultDownloadController を内部生成します。
+        /// 実プロジェクトでは VContainer 等で IAssetVaultService を注入します。
+        /// </summary>
+        public AssetVaultUpdateController(IAssetVaultService assetVaultService)
+        {
+            _assetVaultService = assetVaultService;
+            _downloadController = new AssetVaultDownloadController(assetVaultService);
+        }
+
+        /// <summary>
+        /// 事前ダウンロード実行中の依存関係ダウンロード進捗を通知します。委譲先 controller のストリームをそのまま公開します。
+        /// </summary>
+        public Observable<DownloadProgress> OnProgress => _downloadController.OnProgress;
+
+        /// <summary>
+        /// catalog 更新を確認・適用してから、指定ラベルの未取得分を事前ダウンロードします。
+        /// catalog 確認はリトライ付きで実行し、ラベルが null/空ならダウンロードはスキップします。
+        /// OperationCanceledException は正常系として呼び出し側へ素通しします。
+        /// </summary>
+        /// <param name="labelsToPredownload">事前ダウンロード対象のラベル群。null/空ならダウンロードをスキップ。</param>
+        /// <param name="confirmAsync">サイズ（バイト）を受け取り、ダウンロード続行可否を返す確認処理。null なら確認をスキップ。</param>
+        /// <param name="maxRetryCount">catalog 確認・DL 失敗時の最大リトライ回数。0 ならリトライしない。</param>
+        /// <param name="cancellationToken">キャンセル用トークン。</param>
+        public async UniTask<AssetVaultUpdateResult> RunUpdateAsync(
+            IReadOnlyList<string> labelsToPredownload,
+            Func<long, UniTask<bool>> confirmAsync,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            // --- 1. catalog 更新確認（リトライ付き）。確認＋適用まで service が内包する。 ---
+            CatalogUpdateInfo catalogUpdateInfo;
+            try
+            {
+                catalogUpdateInfo = await CheckForUpdatesWithRetryAsync(maxRetryCount, cancellationToken);
+            }
+            catch (AssetVaultException exception)
+            {
+                // リトライを尽くしても catalog 確認に失敗。差分の入口が開けないため、ダウンロードへは進まず Failed を返す。
+                Debug.LogError($"[AssetVault] catalog update check failed after {maxRetryCount + 1} attempt(s). {exception}");
+                return new AssetVaultUpdateResult(
+                    catalogUpdated: false,
+                    updatedCatalogIds: Array.Empty<string>(),
+                    downloadResult: AssetVaultDownloadResult.Failed);
+            }
+
+            // --- 2. 事前ダウンロード。対象ラベルが無ければ通信も確認も不要。 ---
+            var downloadResult = await PredownloadIfNeededAsync(
+                labelsToPredownload,
+                confirmAsync,
+                maxRetryCount,
+                cancellationToken);
+
+            // --- 3. catalog 結果と DL 結果を束ねて返す。 ---
+            return new AssetVaultUpdateResult(
+                catalogUpdated: catalogUpdateInfo.HasUpdate,
+                updatedCatalogIds: catalogUpdateInfo.UpdatedCatalogIds,
+                downloadResult: downloadResult);
+        }
+
+        /// <summary>
+        /// CheckForUpdatesAsync を最大 maxRetryCount 回まで指数バックオフでリトライします。
+        /// 全て失敗した場合は最後の AssetVaultException を再 throw します。キャンセルはそのまま伝播します。
+        /// </summary>
+        private async UniTask<CatalogUpdateInfo> CheckForUpdatesWithRetryAsync(
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            AssetVaultException lastException = null;
+
+            for (var attempt = 0; attempt <= maxRetryCount; attempt++)
+            {
+                try
+                {
+                    return await _assetVaultService.CheckForUpdatesAsync(cancellationToken);
+                }
+                catch (AssetVaultException exception)
+                {
+                    // 通信由来の再試行可能エラー。最後の試行なら抜けて呼び出し側へ throw する。
+                    lastException = exception;
+                    if (attempt >= maxRetryCount)
+                    {
+                        break;
+                    }
+
+                    await DelayBeforeRetryAsync(attempt, cancellationToken);
+                }
+            }
+
+            throw lastException;
+        }
+
+        /// <summary>
+        /// 事前ダウンロード対象ラベルがあればダウンロードフローを実行し、無ければ NothingToDownload を返します。
+        /// </summary>
+        private UniTask<AssetVaultDownloadResult> PredownloadIfNeededAsync(
+            IReadOnlyList<string> labelsToPredownload,
+            Func<long, UniTask<bool>> confirmAsync,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            if (labelsToPredownload == null || labelsToPredownload.Count <= 0)
+            {
+                return UniTask.FromResult(AssetVaultDownloadResult.NothingToDownload);
+            }
+
+            return _downloadController.EnsureDownloadedAsync(
+                labelsToPredownload,
+                confirmAsync,
+                maxRetryCount,
+                cancellationToken);
+        }
+
+        /// <summary>
+        /// リトライ前に指数バックオフで待機します。間隔計算は <see cref="AssetVaultRetryPolicy"/> に集約しています。
+        /// </summary>
+        private static UniTask DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
+        {
+            var delaySeconds = AssetVaultRetryPolicy.GetBackoffDelaySeconds(attempt);
+            return UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 9bc2b7701059b4163b844c133898da25

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultCacheStatsWindow.cs
@@ -42,7 +42,39 @@ namespace UniLab.AssetVault.Editor
                 EditorGUILayout.LabelField("Pinned Entry Count", stats.PinnedEntryCount.ToString());
                 EditorGUILayout.LabelField("Unreferenced Entry Count", stats.UnreferencedEntryCount.ToString());
                 EditorGUILayout.LabelField("Total Reference Count", stats.TotalReferenceCount.ToString());
+
+                if (AssetVaultCacheStatsRegistry.TryGetEstimatedMemoryBytes(out var estimatedBytes))
+                {
+                    EditorGUILayout.LabelField("Estimated Memory", FormatBytes(estimatedBytes));
+                }
             }
+
+            EditorGUILayout.Space();
+            // 未参照（TTL 猶予中・LRU 超過）エントリを即時解放して、解放挙動を手元で確認できるようにする。
+            if (GUILayout.Button("Trim (release expired / over-capacity)"))
+            {
+                AssetVaultCacheStatsRegistry.TryTrim();
+            }
+        }
+
+        /// <summary>
+        /// バイト数を B/KB/MB の読みやすい表記へ変換します（ASCII 限定）。
+        /// </summary>
+        private static string FormatBytes(long bytes)
+        {
+            const long kiloByte = 1024L;
+            const long megaByte = kiloByte * 1024L;
+            if (bytes >= megaByte)
+            {
+                return $"{bytes / (float)megaByte:F2} MB";
+            }
+
+            if (bytes >= kiloByte)
+            {
+                return $"{bytes / (float)kiloByte:F2} KB";
+            }
+
+            return $"{bytes} B";
         }
 
         private void Update()

--- a/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
+++ b/Assets/UniLab/AssetVault/Interface/IAssetVaultCache.cs
@@ -38,5 +38,10 @@ namespace UniLab.AssetVault
         /// cache の現在の占有状況（エントリ数・参照中・pin 中・参照合計）のスナップショットを取得します。ランタイム診断用です。
         /// </summary>
         AssetVaultCacheStats GetStats();
+
+        /// <summary>
+        /// ロード済みアセットの実行時メモリ量（バイト）を Profiler で概算します。リーク調査・メモリ予算確認用の診断 API です（厳密値ではありません）。
+        /// </summary>
+        long EstimateMemoryBytes();
     }
 }

--- a/Assets/UniLab/AssetVault/Model/AssetVaultUpdateResult.cs
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultUpdateResult.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 「カタログ更新確認 → 差分の事前ダウンロード」を束ねた RunUpdateAsync の最終結果を表します。
+    /// 起動シーケンスがカタログ更新の有無と、後続ダウンロードの結果をまとめて受け取れるようにします。
+    /// </summary>
+    public readonly struct AssetVaultUpdateResult
+    {
+        /// <summary>
+        /// catalog 確認で更新を検出・適用したかどうかを取得します。CheckForUpdatesAsync の HasUpdate を反映します。
+        /// </summary>
+        public bool CatalogUpdated { get; }
+
+        /// <summary>
+        /// 呼び出し側がログ出力や変更内容の確認を行えるよう、確認中に更新された catalog 識別子を取得します。
+        /// </summary>
+        public IReadOnlyList<string> UpdatedCatalogIds { get; }
+
+        /// <summary>
+        /// カタログ確認後に実行した事前ダウンロードフロー（サイズ確認 → ユーザー確認 → リトライ付き DL）の結果を取得します。
+        /// </summary>
+        public AssetVaultDownloadResult DownloadResult { get; }
+
+        /// <summary>
+        /// カタログ更新結果と後続ダウンロード結果をまとめた更新結果を作成します。
+        /// </summary>
+        public AssetVaultUpdateResult(
+            bool catalogUpdated,
+            IReadOnlyList<string> updatedCatalogIds,
+            AssetVaultDownloadResult downloadResult)
+        {
+            CatalogUpdated = catalogUpdated;
+            UpdatedCatalogIds = updatedCatalogIds;
+            DownloadResult = downloadResult;
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/Model/AssetVaultUpdateResult.cs.meta
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultUpdateResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 932c4a1129f8745028e291bc4843b781


### PR DESCRIPTION
## Summary

- **test**: キャッシュ退避(TTL/LRU)とリトライ間隔を純ロジック(`AssetVaultCacheEvictionPolicy`/`AssetVaultRetryPolicy`)化し EditMode テスト追加。Runtime に InternalsVisibleTo
- **feat**: カタログ更新確認→差分事前DLを束ねる `AssetVaultUpdateController` を追加
- **ci**: game-ci で EditMode テスト＋規約ゲートビルド(`AssetVaultCiBuild.BuildNewForCi`)を実行する GitHub Actions を追加（要 UNITY_LICENSE 等 secrets）
- **feat**: `IAssetVaultCache.EstimateMemoryBytes()` と Cache Stats ウィンドウのメモリ表示・Trim ボタンを追加