### PR TITLE
feat: AssetVault の起動シーケンス追加とリトライ共通化

### DIFF
--- a/Assets/UniLab/AssetVault/AddressablesAssetVaultService.cs
+++ b/Assets/UniLab/AssetVault/AddressablesAssetVaultService.cs
@@ -63,6 +63,7 @@ namespace UniLab.AssetVault
             }
             catch (OperationCanceledException)
             {
+                // 初期化キャンセルは正常系。まだ準備できていないため NotInitialized へ戻し、アプリ側の再初期化に委ねる。
                 _state.Value = AssetVaultState.NotInitialized;
                 throw;
             }
@@ -130,6 +131,7 @@ namespace UniLab.AssetVault
             }
             catch (OperationCanceledException)
             {
+                // DL キャンセルは正常系。初期化は済んでおり配信基盤は使えるため、Failed ではなく Ready へ戻す。
                 _state.Value = AssetVaultState.Ready;
                 throw;
             }

--- a/Assets/UniLab/AssetVault/AssetVaultBootstrapper.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultBootstrapper.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UnityEngine;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// アプリ起動時の「初期化 → カタログ更新確認 → 初期必須アセットの事前ダウンロード」を1呼び出しに束ねる起動シーケンス部品です。
+    /// 個々の部品（InitializeAsync / AssetVaultUpdateController）の呼び出し順とリトライ・失敗ハンドリングをここに集約し、
+    /// アプリ側は BaseUrl・初期DLラベル・確認ダイアログを渡して StartAsync を1回呼ぶだけで起動準備を完了できます。
+    /// </summary>
+    public sealed class AssetVaultBootstrapper
+    {
+        private readonly IAssetVaultService _assetVaultService;
+        private readonly AssetVaultUpdateController _updateController;
+
+        /// <summary>
+        /// 対象の vault service を注入して起動シーケンスを作成します。内部でカタログ更新・DL 用の AssetVaultUpdateController を生成します。
+        /// 実プロジェクトでは VContainer 等で IAssetVaultService を注入します。
+        /// </summary>
+        public AssetVaultBootstrapper(IAssetVaultService assetVaultService)
+        {
+            _assetVaultService = assetVaultService;
+            _updateController = new AssetVaultUpdateController(assetVaultService);
+        }
+
+        /// <summary>
+        /// 配信基盤“全体”の状態を取得します。アプリは全体ローディング UI（初期化中・DL 中・失敗）の表示制御に使います。
+        /// </summary>
+        public ReadOnlyReactiveProperty<AssetVaultState> State => _assetVaultService.State;
+
+        /// <summary>
+        /// 初期事前ダウンロード実行中の進捗を通知します。委譲先 controller のストリームをそのまま公開します。
+        /// </summary>
+        public Observable<DownloadProgress> OnProgress => _updateController.OnProgress;
+
+        /// <summary>
+        /// 起動シーケンスを実行します。初期化（リトライ付き）に成功したら、カタログ更新確認と初期必須アセットの事前ダウンロードまで行います。
+        /// OperationCanceledException は正常系として呼び出し側へ素通しします。
+        /// </summary>
+        /// <param name="baseUrl">配信先の BaseUrl。Local 専用なら空文字（version 解決をスキップ）。</param>
+        /// <param name="initialDownloadLabels">起動時に先取りしたい必須ラベル群。null/空ならダウンロードをスキップ。</param>
+        /// <param name="confirmAsync">サイズ（バイト）を受け取りダウンロード続行可否を返す確認処理。null なら確認をスキップ。</param>
+        /// <param name="maxRetryCount">初期化・更新・DL 失敗時の最大リトライ回数。0 ならリトライしない。</param>
+        /// <param name="cancellationToken">キャンセル用トークン。</param>
+        public async UniTask<AssetVaultBootstrapResult> StartAsync(
+            string baseUrl,
+            IReadOnlyList<string> initialDownloadLabels,
+            Func<long, UniTask<bool>> confirmAsync,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            // --- 1. 初期化（リトライ付き）。失敗したら以降へ進めないため、ここで打ち切って結果を返す。 ---
+            var initialized = await TryInitializeAsync(baseUrl, maxRetryCount, cancellationToken);
+            if (!initialized)
+            {
+                return new AssetVaultBootstrapResult(initialized: false, updateResult: default);
+            }
+
+            // --- 2. カタログ更新確認 + 初期必須アセットの事前ダウンロード。 ---
+            var updateResult = await _updateController.RunUpdateAsync(
+                initialDownloadLabels,
+                confirmAsync,
+                maxRetryCount,
+                cancellationToken);
+
+            return new AssetVaultBootstrapResult(initialized: true, updateResult: updateResult);
+        }
+
+        /// <summary>
+        /// InitializeAsync を最大 maxRetryCount 回まで指数バックオフでリトライします。
+        /// 全て失敗した場合はログを残して false を返します（致命扱いにせず、アプリ側のリトライ導線に委ねる）。キャンセルは素通しします。
+        /// </summary>
+        private async UniTask<bool> TryInitializeAsync(string baseUrl, int maxRetryCount, CancellationToken cancellationToken)
+        {
+            // リトライ機構は AssetVaultRetry に集約。ここでは成否を bool へ写し、失敗時のログ＋リトライ導線への委譲に専念する。
+            try
+            {
+                await AssetVaultRetry.RunAsync(
+                    token => _assetVaultService.InitializeAsync(baseUrl, token),
+                    maxRetryCount,
+                    cancellationToken);
+                return true;
+            }
+            catch (AssetVaultException exception)
+            {
+                Debug.LogError($"[AssetVault] initialization failed after {maxRetryCount + 1} attempt(s). {exception}");
+                return false;
+            }
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultBootstrapper.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultBootstrapper.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3ea1f3879fc0e4725948a68464ff7ece

--- a/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultDownloadController.cs
@@ -59,52 +59,21 @@ namespace UniLab.AssetVault
                 }
             }
 
-            // --- 3. リトライ付きダウンロード。 ---
-            return await DownloadWithRetryAsync(labels, maxRetryCount, cancellationToken);
-        }
-
-        /// <summary>
-        /// DownloadAsync を最大 maxRetryCount 回まで指数バックオフでリトライします。キャンセルは再 throw します。
-        /// </summary>
-        private async UniTask<AssetVaultDownloadResult> DownloadWithRetryAsync(
-            IReadOnlyList<string> labels,
-            int maxRetryCount,
-            CancellationToken cancellationToken)
-        {
-            AssetVaultException lastException = null;
-
-            for (var attempt = 0; attempt <= maxRetryCount; attempt++)
+            // --- 3. リトライ付きダウンロード。リトライ機構は AssetVaultRetry に集約し、ここでは結果を Result へ写すだけ。 ---
+            try
             {
-                try
-                {
-                    await _assetVaultService.DownloadAsync(labels, cancellationToken);
-                    return AssetVaultDownloadResult.Completed;
-                }
-                catch (AssetVaultException exception)
-                {
-                    // ロード/通信由来の再試行可能エラー。最後の試行なら抜けてログ＋Failed へ。
-                    lastException = exception;
-                    if (attempt >= maxRetryCount)
-                    {
-                        break;
-                    }
-
-                    await DelayBeforeRetryAsync(attempt, cancellationToken);
-                }
+                await AssetVaultRetry.RunAsync(
+                    token => _assetVaultService.DownloadAsync(labels, token),
+                    maxRetryCount,
+                    cancellationToken);
+                return AssetVaultDownloadResult.Completed;
             }
-
-            // 例外メッセージ・ログは英語、コメント/summary は日本語の方針に従う。
-            Debug.LogError($"[AssetVault] download failed after {maxRetryCount + 1} attempt(s). {lastException}");
-            return AssetVaultDownloadResult.Failed;
-        }
-
-        /// <summary>
-        /// リトライ前に指数バックオフで待機します。間隔計算は <see cref="AssetVaultRetryPolicy"/> に集約しています。
-        /// </summary>
-        private static UniTask DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
-        {
-            var delaySeconds = AssetVaultRetryPolicy.GetBackoffDelaySeconds(attempt);
-            return UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
+            catch (AssetVaultException exception)
+            {
+                // リトライを尽くしても失敗。例外メッセージ・ログは英語、コメント/summary は日本語の方針に従う。
+                Debug.LogError($"[AssetVault] download failed after {maxRetryCount + 1} attempt(s). {exception}");
+                return AssetVaultDownloadResult.Failed;
+            }
         }
     }
 }

--- a/Assets/UniLab/AssetVault/AssetVaultRetry.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultRetry.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// AssetVaultException を指数バックオフでリトライしながら非同期操作を実行する共通ヘルパーです。
+    /// 初期化・カタログ更新・ダウンロードに散在していたリトライループを一本化します（間隔計算は <see cref="AssetVaultRetryPolicy"/> に委譲）。
+    /// </summary>
+    internal static class AssetVaultRetry
+    {
+        /// <summary>
+        /// operation を実行し、<see cref="AssetVaultException"/> が出たら最大 maxRetryCount 回まで指数バックオフでリトライします。
+        /// 成功すればその結果を返し、全試行が失敗したら最後の例外を再 throw します。
+        /// OperationCanceledException はリトライ対象にせず、そのまま呼び出し側へ伝播します。
+        /// </summary>
+        internal static async UniTask<T> RunAsync<T>(
+            Func<CancellationToken, UniTask<T>> operation,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            AssetVaultException lastException = null;
+
+            for (var attempt = 0; attempt <= maxRetryCount; attempt++)
+            {
+                try
+                {
+                    return await operation(cancellationToken);
+                }
+                catch (AssetVaultException exception)
+                {
+                    // 通信断など再試行で復帰し得るエラー。最後の試行なら抜けて呼び出し側へ再 throw する。
+                    lastException = exception;
+                    if (attempt >= maxRetryCount)
+                    {
+                        break;
+                    }
+
+                    var delaySeconds = AssetVaultRetryPolicy.GetBackoffDelaySeconds(attempt);
+                    await UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
+                }
+            }
+
+            throw lastException;
+        }
+
+        /// <summary>
+        /// 戻り値の無い操作向けのオーバーロードです。リトライ挙動は <see cref="RunAsync{T}"/> と同じです。
+        /// </summary>
+        internal static async UniTask RunAsync(
+            Func<CancellationToken, UniTask> operation,
+            int maxRetryCount,
+            CancellationToken cancellationToken)
+        {
+            await RunAsync(
+                async token =>
+                {
+                    await operation(token);
+                    return true;
+                },
+                maxRetryCount,
+                cancellationToken);
+        }
+    }
+}

--- a/Assets/UniLab/AssetVault/AssetVaultRetry.cs.meta
+++ b/Assets/UniLab/AssetVault/AssetVaultRetry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ce7379bda08d04f11b06b740101bac1e

--- a/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultRuntime.cs
@@ -8,11 +8,11 @@ namespace UniLab.AssetVault
         /// <summary>
         /// 環境ごとのホスト込み基底 URL です（例 https://dev1.xxx.xxx/app）。env から URL へのマッピングはアプリ config が持ちます。
         /// </summary>
-        public static string BaseUrl { get; set; } = null;
+        public static string BaseUrl { get; set; }
 
         /// <summary>
         /// version.json の path です。RemoteLoadPath の不透明な版セグメントに使われます。
         /// </summary>
-        public static string ContentPath { get; set; } = null;
+        public static string ContentPath { get; set; }
     }
 }

--- a/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs
+++ b/Assets/UniLab/AssetVault/AssetVaultUpdateController.cs
@@ -47,11 +47,14 @@ namespace UniLab.AssetVault
             int maxRetryCount,
             CancellationToken cancellationToken)
         {
-            // --- 1. catalog 更新確認（リトライ付き）。確認＋適用まで service が内包する。 ---
+            // --- 1. catalog 更新確認（リトライ付き）。確認＋適用まで service が内包する。リトライ機構は AssetVaultRetry に集約。 ---
             CatalogUpdateInfo catalogUpdateInfo;
             try
             {
-                catalogUpdateInfo = await CheckForUpdatesWithRetryAsync(maxRetryCount, cancellationToken);
+                catalogUpdateInfo = await AssetVaultRetry.RunAsync(
+                    token => _assetVaultService.CheckForUpdatesAsync(token),
+                    maxRetryCount,
+                    cancellationToken);
             }
             catch (AssetVaultException exception)
             {
@@ -78,38 +81,6 @@ namespace UniLab.AssetVault
         }
 
         /// <summary>
-        /// CheckForUpdatesAsync を最大 maxRetryCount 回まで指数バックオフでリトライします。
-        /// 全て失敗した場合は最後の AssetVaultException を再 throw します。キャンセルはそのまま伝播します。
-        /// </summary>
-        private async UniTask<CatalogUpdateInfo> CheckForUpdatesWithRetryAsync(
-            int maxRetryCount,
-            CancellationToken cancellationToken)
-        {
-            AssetVaultException lastException = null;
-
-            for (var attempt = 0; attempt <= maxRetryCount; attempt++)
-            {
-                try
-                {
-                    return await _assetVaultService.CheckForUpdatesAsync(cancellationToken);
-                }
-                catch (AssetVaultException exception)
-                {
-                    // 通信由来の再試行可能エラー。最後の試行なら抜けて呼び出し側へ throw する。
-                    lastException = exception;
-                    if (attempt >= maxRetryCount)
-                    {
-                        break;
-                    }
-
-                    await DelayBeforeRetryAsync(attempt, cancellationToken);
-                }
-            }
-
-            throw lastException;
-        }
-
-        /// <summary>
         /// 事前ダウンロード対象ラベルがあればダウンロードフローを実行し、無ければ NothingToDownload を返します。
         /// </summary>
         private UniTask<AssetVaultDownloadResult> PredownloadIfNeededAsync(
@@ -128,15 +99,6 @@ namespace UniLab.AssetVault
                 confirmAsync,
                 maxRetryCount,
                 cancellationToken);
-        }
-
-        /// <summary>
-        /// リトライ前に指数バックオフで待機します。間隔計算は <see cref="AssetVaultRetryPolicy"/> に集約しています。
-        /// </summary>
-        private static UniTask DelayBeforeRetryAsync(int attempt, CancellationToken cancellationToken)
-        {
-            var delaySeconds = AssetVaultRetryPolicy.GetBackoffDelaySeconds(attempt);
-            return UniTask.Delay(TimeSpan.FromSeconds(delaySeconds), cancellationToken: cancellationToken);
         }
     }
 }

--- a/Assets/UniLab/AssetVault/Model/AssetVaultBootstrapResult.cs
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultBootstrapResult.cs
@@ -1,0 +1,29 @@
+namespace UniLab.AssetVault
+{
+    /// <summary>
+    /// 起動シーケンス（初期化 → カタログ更新確認 → 初期必須アセットの事前ダウンロード）の最終結果です。
+    /// アプリは Initialized と各結果を見て、ローディング解除・リトライ導線・致命エラー表示を出し分けます。
+    /// </summary>
+    public readonly struct AssetVaultBootstrapResult
+    {
+        /// <summary>
+        /// 初期化結果と更新結果をまとめた起動結果を作成します。
+        /// </summary>
+        public AssetVaultBootstrapResult(bool initialized, AssetVaultUpdateResult updateResult)
+        {
+            Initialized = initialized;
+            UpdateResult = updateResult;
+        }
+
+        /// <summary>InitializeAsync が（リトライ込みで）成功したかどうかです。false なら配信基盤が使えず、初期化のリトライが必要です。</summary>
+        public bool Initialized { get; }
+
+        /// <summary>初期化後のカタログ更新確認と初期事前ダウンロードの結果です。Initialized が false のときは既定値です。</summary>
+        public AssetVaultUpdateResult UpdateResult { get; }
+
+        /// <summary>
+        /// 起動が完了し、ゲーム本編へ進んでよい状態かどうかを取得します（初期化成功かつ初期ダウンロードが失敗していない）。
+        /// </summary>
+        public bool IsReady => Initialized && UpdateResult.DownloadResult != AssetVaultDownloadResult.Failed;
+    }
+}

--- a/Assets/UniLab/AssetVault/Model/AssetVaultBootstrapResult.cs.meta
+++ b/Assets/UniLab/AssetVault/Model/AssetVaultBootstrapResult.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 09d0c3007f3de4d3b90d0d6d727ce663


### PR DESCRIPTION
- refactor: 初期化/カタログ更新/DL の3箇所に重複していたリトライループを `AssetVaultRetry` に集約。キャンセル時の復帰状態に Why コメント追加、冗長な `= null` 除去
- feat: 初期化(リトライ)→カタログ更新→初期必須DL を1呼び出しに束ねる `AssetVaultBootstrapper`（`StartAsync`）と結果型 `AssetVaultBootstrapResult` を追加