### PR TITLE
feat: Network に API シリアライザ抽象 IApiSerializer を導入

### DIFF
--- a/Assets/Editor/Tests/UniLab/Network/ApiExceptionTest.cs
+++ b/Assets/Editor/Tests/UniLab/Network/ApiExceptionTest.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using NUnit.Framework;
 using UniLab.Network;
 
@@ -8,26 +9,28 @@ namespace UniLab.Tests.EditMode.Network
         [Test]
         public void ApiException_StoresStatusCodeAndBody()
         {
-            var exception = new ApiException(500, "Internal Server Error", "server error");
+            var responseBody = Encoding.UTF8.GetBytes("Internal Server Error");
+            var exception = new ApiException(500, responseBody, "server error");
 
             Assert.AreEqual(500, exception.StatusCode);
-            Assert.AreEqual("Internal Server Error", exception.ResponseBody);
+            Assert.AreEqual("Internal Server Error", exception.ResponseBodyAsString);
             Assert.AreEqual("server error", exception.Message);
         }
 
         [Test]
         public void UnauthorizedException_HasStatus401()
         {
-            var exception = new UnauthorizedException("body");
+            var responseBody = Encoding.UTF8.GetBytes("body");
+            var exception = new UnauthorizedException(responseBody);
 
             Assert.AreEqual(401, exception.StatusCode);
-            Assert.AreEqual("body", exception.ResponseBody);
+            Assert.AreEqual("body", exception.ResponseBodyAsString);
         }
 
         [Test]
         public void UnauthorizedException_IsApiException()
         {
-            var exception = new UnauthorizedException("body");
+            var exception = new UnauthorizedException(Encoding.UTF8.GetBytes("body"));
 
             Assert.IsInstanceOf<ApiException>(exception);
         }
@@ -35,7 +38,7 @@ namespace UniLab.Tests.EditMode.Network
         [Test]
         public void TooManyRequestsException_HasStatus429()
         {
-            var exception = new TooManyRequestsException("rate limited");
+            var exception = new TooManyRequestsException(Encoding.UTF8.GetBytes("rate limited"));
 
             Assert.AreEqual(429, exception.StatusCode);
         }
@@ -43,7 +46,7 @@ namespace UniLab.Tests.EditMode.Network
         [Test]
         public void ServiceUnavailableException_HasStatus503()
         {
-            var exception = new ServiceUnavailableException("down");
+            var exception = new ServiceUnavailableException(Encoding.UTF8.GetBytes("down"));
 
             Assert.AreEqual(503, exception.StatusCode);
         }
@@ -51,9 +54,17 @@ namespace UniLab.Tests.EditMode.Network
         [Test]
         public void AllDerivedExceptions_AreApiException()
         {
-            Assert.IsInstanceOf<ApiException>(new UnauthorizedException(""));
-            Assert.IsInstanceOf<ApiException>(new TooManyRequestsException(""));
-            Assert.IsInstanceOf<ApiException>(new ServiceUnavailableException(""));
+            Assert.IsInstanceOf<ApiException>(new UnauthorizedException(new byte[0]));
+            Assert.IsInstanceOf<ApiException>(new TooManyRequestsException(new byte[0]));
+            Assert.IsInstanceOf<ApiException>(new ServiceUnavailableException(new byte[0]));
+        }
+
+        [Test]
+        public void ResponseBodyAsString_NullSafe_WhenResponseBodyIsNull()
+        {
+            var exception = new ApiException(500, null, "server error");
+
+            Assert.AreEqual(string.Empty, exception.ResponseBodyAsString);
         }
     }
 }

--- a/Assets/Editor/Tests/UniLab/Network/JsonUtilityApiSerializerTest.cs
+++ b/Assets/Editor/Tests/UniLab/Network/JsonUtilityApiSerializerTest.cs
@@ -1,0 +1,70 @@
+using System;
+using NUnit.Framework;
+using UniLab.Network;
+
+namespace UniLab.Tests.EditMode.Network
+{
+    public class JsonUtilityApiSerializerTest
+    {
+        private JsonUtilityApiSerializer _serializer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _serializer = new JsonUtilityApiSerializer();
+        }
+
+        [Test]
+        public void ContentType_Is_ApplicationJson()
+        {
+            Assert.AreEqual("application/json", _serializer.ContentType);
+        }
+
+        [Test]
+        public void Serialize_ThenDeserialize_RoundTrips()
+        {
+            var original = new SampleDto { Name = "UniLab", Value = 42 };
+
+            var bytes = _serializer.Serialize(original);
+            var result = _serializer.Deserialize<SampleDto>(bytes);
+
+            Assert.AreEqual(original.Name, result.Name);
+            Assert.AreEqual(original.Value, result.Value);
+        }
+
+        [Test]
+        public void Serialize_ProducesUtf8WithoutBom()
+        {
+            var data = new SampleDto { Name = "test", Value = 1 };
+
+            var bytes = _serializer.Serialize(data);
+
+            Assert.IsTrue(bytes.Length >= 3, "Expected non-trivial output");
+            var startsWithBom = bytes[0] == 0xEF && bytes[1] == 0xBB && bytes[2] == 0xBF;
+            Assert.IsFalse(startsWithBom, "Output must not start with a UTF-8 BOM");
+        }
+
+        [Test]
+        public void Deserialize_EmptyBytes_ReturnsDefault()
+        {
+            var result = _serializer.Deserialize<SampleDto>(new byte[0]);
+
+            Assert.IsNull(result);
+        }
+
+        [Test]
+        public void Deserialize_NullBytes_ReturnsDefault()
+        {
+            var result = _serializer.Deserialize<SampleDto>(null);
+
+            Assert.IsNull(result);
+        }
+
+        [Serializable]
+        private class SampleDto
+        {
+            public string Name;
+            public int Value;
+        }
+    }
+}

--- a/Assets/Editor/Tests/UniLab/Network/JsonUtilityApiSerializerTest.cs.meta
+++ b/Assets/Editor/Tests/UniLab/Network/JsonUtilityApiSerializerTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 668719b3c0ccba7478334c3e6511716f

--- a/Assets/UniLab/Network/ApiClientBase.cs
+++ b/Assets/UniLab/Network/ApiClientBase.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading;
 using Cysharp.Threading.Tasks;
-using UnityEngine;
 using UnityEngine.Networking;
 
 namespace UniLab.Network
@@ -24,6 +23,26 @@ namespace UniLab.Network
         /// Timeout seconds per request attempt. Override in subclass constructor if needed.
         /// </summary>
         protected int _timeoutSeconds = 10;
+
+        private readonly IApiSerializer _serializer;
+
+        // --- Constructors ---
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ApiClientBase"/> with the default
+        /// <see cref="JsonUtilityApiSerializer"/>.
+        /// </summary>
+        protected ApiClientBase() : this(new JsonUtilityApiSerializer())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="ApiClientBase"/> with a custom serializer.
+        /// </summary>
+        protected ApiClientBase(IApiSerializer serializer)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+        }
 
         // --- Abstract members ---
 
@@ -51,7 +70,7 @@ namespace UniLab.Network
         }
 
         /// <summary>
-        /// Sends a POST request with a JSON-serialized <paramref name="body"/> to <paramref name="path"/>
+        /// Sends a POST request with a serialized <paramref name="body"/> to <paramref name="path"/>
         /// and deserializes the response as <typeparamref name="TResponse"/>.
         /// </summary>
         protected async UniTask<TResponse> PostAsync<TResponse, TRequest>(
@@ -60,10 +79,10 @@ namespace UniLab.Network
             CancellationToken cancellationToken = default)
         {
             var url = BuildUrl(path);
-            var json = JsonUtility.ToJson(body);
-            var uploadHandler = new UploadHandlerRaw(System.Text.Encoding.UTF8.GetBytes(json))
+            var bodyBytes = _serializer.Serialize(body);
+            var uploadHandler = new UploadHandlerRaw(bodyBytes)
             {
-                contentType = "application/json"
+                contentType = _serializer.ContentType
             };
             using var request = new UnityWebRequest(url, UnityWebRequest.kHttpVerbPOST)
             {
@@ -93,7 +112,7 @@ namespace UniLab.Network
 
         private void SetCommonHeaders(UnityWebRequest request)
         {
-            request.SetRequestHeader("Accept", "application/json");
+            request.SetRequestHeader("Accept", _serializer.ContentType);
 
             var token = GetAccessToken();
             if (!string.IsNullOrEmpty(token))
@@ -115,21 +134,26 @@ namespace UniLab.Network
 
             if (request.result == UnityWebRequest.Result.Success)
             {
-                var responseText = request.downloadHandler.text;
-                return JsonUtility.FromJson<TResponse>(responseText);
+                var responseBytes = request.downloadHandler?.data;
+                if (statusCode == 204 || responseBytes == null || responseBytes.Length == 0)
+                {
+                    return default;
+                }
+
+                return _serializer.Deserialize<TResponse>(responseBytes);
             }
 
-            var responseBody = request.downloadHandler?.text ?? string.Empty;
+            var responseBodyBytes = request.downloadHandler?.data ?? Array.Empty<byte>();
 
             if (statusCode == 401)
             {
                 OnUnauthorized();
-                throw new UnauthorizedException(responseBody);
+                throw new UnauthorizedException(responseBodyBytes);
             }
 
             if (statusCode == 400 || statusCode == 404)
             {
-                throw new ApiException(statusCode, responseBody, $"Request failed with status {statusCode}.");
+                throw new ApiException(statusCode, responseBodyBytes, $"Request failed with status {statusCode}.");
             }
 
             // Retry only on 429 and 5xx (transient errors).
@@ -147,15 +171,15 @@ namespace UniLab.Network
 
             if (statusCode == 429)
             {
-                throw new TooManyRequestsException(responseBody);
+                throw new TooManyRequestsException(responseBodyBytes);
             }
 
             if (statusCode == 503)
             {
-                throw new ServiceUnavailableException(responseBody);
+                throw new ServiceUnavailableException(responseBodyBytes);
             }
 
-            throw new ApiException(statusCode, responseBody, $"Request failed with status {statusCode}.");
+            throw new ApiException(statusCode, responseBodyBytes, $"Request failed with status {statusCode}.");
         }
 
         /// <summary>

--- a/Assets/UniLab/Network/ApiException.cs
+++ b/Assets/UniLab/Network/ApiException.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 
 namespace UniLab.Network
 {
@@ -10,13 +11,19 @@ namespace UniLab.Network
         /// <summary>HTTP status code returned by the server.</summary>
         public int StatusCode { get; }
 
-        /// <summary>Raw response body returned by the server.</summary>
-        public string ResponseBody { get; }
+        /// <summary>Raw response body bytes returned by the server.</summary>
+        public byte[] ResponseBody { get; }
+
+        /// <summary>
+        /// UTF-8 decoded representation of <see cref="ResponseBody"/>.
+        /// Returns an empty string when <see cref="ResponseBody"/> is <c>null</c>.
+        /// </summary>
+        public string ResponseBodyAsString => ResponseBody == null ? string.Empty : Encoding.UTF8.GetString(ResponseBody);
 
         /// <summary>
         /// Initializes a new instance of <see cref="ApiException"/>.
         /// </summary>
-        public ApiException(int statusCode, string responseBody, string message)
+        public ApiException(int statusCode, byte[] responseBody, string message)
             : base(message)
         {
             StatusCode = statusCode;
@@ -32,7 +39,7 @@ namespace UniLab.Network
         /// <summary>
         /// Initializes a new instance of <see cref="UnauthorizedException"/>.
         /// </summary>
-        public UnauthorizedException(string responseBody)
+        public UnauthorizedException(byte[] responseBody)
             : base(401, responseBody, "Unauthorized: access token is invalid or expired.")
         {
         }
@@ -46,7 +53,7 @@ namespace UniLab.Network
         /// <summary>
         /// Initializes a new instance of <see cref="TooManyRequestsException"/>.
         /// </summary>
-        public TooManyRequestsException(string responseBody)
+        public TooManyRequestsException(byte[] responseBody)
             : base(429, responseBody, "Too many requests: rate limit exceeded.")
         {
         }
@@ -60,7 +67,7 @@ namespace UniLab.Network
         /// <summary>
         /// Initializes a new instance of <see cref="ServiceUnavailableException"/>.
         /// </summary>
-        public ServiceUnavailableException(string responseBody)
+        public ServiceUnavailableException(byte[] responseBody)
             : base(503, responseBody, "Service unavailable: the server is temporarily down.")
         {
         }

--- a/Assets/UniLab/Network/IApiSerializer.cs
+++ b/Assets/UniLab/Network/IApiSerializer.cs
@@ -1,0 +1,26 @@
+namespace UniLab.Network
+{
+    /// <summary>
+    /// Abstracts HTTP body serialization and deserialization.
+    /// Implement this interface to plug in alternative serializers such as Newtonsoft.Json,
+    /// MessagePack, or MemoryPack without modifying <see cref="ApiClientBase"/>.
+    /// </summary>
+    public interface IApiSerializer
+    {
+        /// <summary>
+        /// MIME type sent as both the <c>Content-Type</c> and <c>Accept</c> HTTP headers.
+        /// Example: <c>"application/json"</c>, <c>"application/x-msgpack"</c>.
+        /// </summary>
+        string ContentType { get; }
+
+        /// <summary>
+        /// Encodes <paramref name="value"/> into the raw bytes that will be sent as the HTTP request body.
+        /// </summary>
+        byte[] Serialize<T>(T value);
+
+        /// <summary>
+        /// Decodes <paramref name="body"/> received from the HTTP response into <typeparamref name="T"/>.
+        /// </summary>
+        T Deserialize<T>(byte[] body);
+    }
+}

--- a/Assets/UniLab/Network/IApiSerializer.cs.meta
+++ b/Assets/UniLab/Network/IApiSerializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 00df264f343bd994784b2168b35c3674

--- a/Assets/UniLab/Network/JsonUtilityApiSerializer.cs
+++ b/Assets/UniLab/Network/JsonUtilityApiSerializer.cs
@@ -1,0 +1,41 @@
+using System.Text;
+using UnityEngine;
+
+namespace UniLab.Network
+{
+    /// <summary>
+    /// Default <see cref="IApiSerializer"/> implementation backed by <see cref="JsonUtility"/>.
+    /// Encodes and decodes UTF-8 JSON without a BOM.
+    /// </summary>
+    public sealed class JsonUtilityApiSerializer : IApiSerializer
+    {
+        /// <summary>
+        /// Returns <c>"application/json"</c>.
+        /// </summary>
+        public string ContentType => "application/json";
+
+        /// <summary>
+        /// Serializes <paramref name="value"/> to a UTF-8 JSON byte array without a BOM.
+        /// </summary>
+        public byte[] Serialize<T>(T value)
+        {
+            var json = JsonUtility.ToJson(value);
+            return Encoding.UTF8.GetBytes(json);
+        }
+
+        /// <summary>
+        /// Deserializes a UTF-8 JSON byte array into <typeparamref name="T"/>.
+        /// Returns <c>null</c> (or the default value for value types) when <paramref name="body"/> is empty.
+        /// </summary>
+        public T Deserialize<T>(byte[] body)
+        {
+            if (body == null || body.Length == 0)
+            {
+                return default;
+            }
+
+            var json = Encoding.UTF8.GetString(body);
+            return JsonUtility.FromJson<T>(json);
+        }
+    }
+}

--- a/Assets/UniLab/Network/JsonUtilityApiSerializer.cs.meta
+++ b/Assets/UniLab/Network/JsonUtilityApiSerializer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c99fb76f19d4f5e459a8308400d5c123


### PR DESCRIPTION
## 概要

`UniLab.Network.ApiClientBase` の JSON シリアライズを `IApiSerializer` 抽象化に置換し、MessagePack/Newtonsoft/MemoryPack 等への差し替えを **UniLab.Network 本体を変更せず** 実装可能にする。

Phase 1: 抽象化 + JsonUtility デフォルト実装まで。MessagePack 実装 (`UniLab.Network.MessagePack` 別 asmdef) と設計ドキュメントは別 PR で。

## 変更内容

### 新規

- `IApiSerializer` インターフェース — `ContentType` / `Serialize<T>` / `Deserialize<T>` を持つ byte[] ベース抽象
- `JsonUtilityApiSerializer` — `UnityEngine.JsonUtility` ベースのデフォルト実装
- `JsonUtilityApiSerializerTest` — EditMode テスト (round-trip / BOM / 空 byte / null byte)

### 既存改修

- `ApiClientBase`
  - コンストラクタ注入対応 (引数なし ctor は `JsonUtilityApiSerializer` をデフォルト同梱、**後方互換**)
  - null ガード追加 (`ArgumentNullException`)
  - `Accept` ヘッダを `_serializer.ContentType` 経由に変更
  - 成功パスを `downloadHandler.data` (byte[]) ベースに変更
  - **204 / 空ボディガード追加** (`default` 返却)
  - エラーパスも byte[] ベースに変更
- `ApiException` (**破壊的変更**)
  - `ResponseBody` の型を `string` → `byte[]`
  - `ResponseBodyAsString` 補助プロパティ追加 (UTF-8 文字列表現、null 安全)
  - 派生例外 `UnauthorizedException` / `TooManyRequestsException` / `ServiceUnavailableException` のコンストラクタ引数も byte[] 化
- `ApiExceptionTest` — byte[] ベースへ更新、null 安全テスト追加

## 設計判断

- **byte[] ベース**: HTTP body の本質に合わせる。バイナリ形式 (MessagePack) を Base64 で string に押し込む汚染を回避。
- **コンストラクタ注入**: abstract property だとサブクラスごとに形式が混ざる危険があるため一本化。
- **エラー body も byte[]**: バイナリ API でもエラーは JSON のことが多いため、利用側で個別パース可能に。
- **204 ガードは ApiClientBase 側に置く**: MessagePack/MemoryPack は空 byte[] で例外を吐くため、シリアライザ層では受け切れない。

## Phase 2 以降 (本 PR 対象外)

- `UniLab.Network.MessagePack` asmdef + `MessagePackApiSerializer`
- `IApiErrorSerializer` (バイナリ API + JSON エラー運用が出てきたら)
- 設計ドキュメント `docs/design-unilab-network.md`
- `OnUnauthorizedAsync()` 化と auto-refresh
- PUT/DELETE/PATCH 追加
- timeout を retry 対象に

## Test plan

- [ ] DOTween Pro 復旧後に Unity を起動し、EditMode テストが全て緑になることを確認
- [ ] 既存の `ApiClientBase` を継承している実装がある場合、コンパイルが通ることを確認 (引数なし ctor は維持されているので影響なしのはず)
- [ ] `ApiException.ResponseBody` を `string` として参照している箇所があれば `ResponseBodyAsString` に置換

## 注意事項

- ローカル環境では DOTween Pro が未インポートのため `UniTask.DOTween` 連携がコンパイル不可。EditMode テストの動作確認は DOTween 復旧後に。本 PR の変更自体は DOTween 非依存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)