### PR TITLE
Popup: ロード手段の抽象化・CloseAllAsync・テスト追加

### DIFF
--- a/Assets/Tests/PlayMode/UniLab/Popup/PopupServiceTest.cs
+++ b/Assets/Tests/PlayMode/UniLab/Popup/PopupServiceTest.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using NUnit.Framework;
+using R3;
 using UnityEngine;
 using UnityEngine.TestTools;
 using UnityEngine.UI;
@@ -149,6 +150,78 @@ namespace UniLab.UI.Popup.Tests
             // PopupService は SetActive(true) を呼ぶため初期非表示にしておく
             gameObject.SetActive(false);
             return popup;
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // 追加テストダブル
+    // ---------------------------------------------------------------------------
+
+    /// <summary>
+    /// テスト用の IPopupDimmer モック。Subject&lt;Unit&gt; でクリックを発火し、
+    /// Show/Hide の呼び出し回数と現在の可視状態を記録する。
+    /// </summary>
+    internal sealed class MockPopupDimmer : IPopupDimmer
+    {
+        private readonly Subject<Unit> _clickSubject = new();
+
+        /// <summary>暗幕タップ通知。PopupService が購読する。</summary>
+        public Observable<Unit> OnClick => _clickSubject;
+
+        /// <summary>Show が呼ばれた回数。</summary>
+        public int ShowCallCount { get; private set; }
+
+        /// <summary>Hide が呼ばれた回数。</summary>
+        public int HideCallCount { get; private set; }
+
+        /// <summary>現在 Show 状態か。</summary>
+        public bool IsVisible { get; private set; }
+
+        /// <summary>外部からクリックイベントを発火する。</summary>
+        public void EmitClick()
+        {
+            _clickSubject.OnNext(Unit.Default);
+        }
+
+        /// <summary>暗幕を表示状態にする。</summary>
+        public void Show(Transform popupTransform)
+        {
+            ShowCallCount++;
+            IsVisible = true;
+        }
+
+        /// <summary>暗幕を非表示にする。</summary>
+        public void Hide()
+        {
+            HideCallCount++;
+            IsVisible = false;
+        }
+    }
+
+    /// <summary>
+    /// PlayOpenAsync / PlayCloseAsync の呼び出し回数を記録するトランジション。
+    /// アニメーションは持たず即座に完了する。
+    /// </summary>
+    internal sealed class RecordingPopupTransition : PopupTransitionBase
+    {
+        /// <summary>PlayOpenAsync が呼ばれた回数。</summary>
+        public int OpenCallCount { get; private set; }
+
+        /// <summary>PlayCloseAsync が呼ばれた回数。</summary>
+        public int CloseCallCount { get; private set; }
+
+        /// <summary>開くアニメーション再生を記録して即完了する。</summary>
+        public override UniTask PlayOpenAsync(CancellationToken cancellationToken)
+        {
+            OpenCallCount++;
+            return UniTask.CompletedTask;
+        }
+
+        /// <summary>閉じるアニメーション再生を記録して即完了する。</summary>
+        public override UniTask PlayCloseAsync(CancellationToken cancellationToken)
+        {
+            CloseCallCount++;
+            return UniTask.CompletedTask;
         }
     }
 
@@ -571,6 +644,323 @@ namespace UniLab.UI.Popup.Tests
             // テスト後始末: 手動で Resolve して ShowAsync を終了させる
             popup.Resolve(0);
             yield return showTask.ToCoroutine();
+        }
+
+        // ---------------------------------------------------------------------------
+        // テストケース 8: スタック同時表示
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// Stack=false のベース表示後に Stack=true を重ね、両方が同時に表示されること。
+        /// スタック上のポップアップを閉じてもベースは引き続き表示されること。
+        /// 最後にベースを閉じると両方 Release されること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ShowAsync_StackTrue_OverlaysOnTopOfBase()
+        {
+            // Arrange
+            var basePopup = MockPopupFactory.Create("Base");
+            var stackedPopup = MockPopupFactory.Create("Stacked");
+            _viewProvider.EnqueueInstance(basePopup);
+            _viewProvider.EnqueueInstance(stackedPopup);
+
+            var baseParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                Stack = false,
+            };
+            var stackParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                Stack = true,
+            };
+
+            // Act: ベースを Forget 表示し 1 フレーム待ってから Stack=true を重ねる
+            _service.ShowAsync<MockResultPopup, int>(baseParameter).Forget();
+            yield return null;
+
+            Assert.AreEqual(1, _viewProvider.LoadCallCount, "ベース表示で LoadAsync が 1 回呼ばれること");
+
+            _service.ShowAsync<MockResultPopup, int>(stackParameter).Forget();
+            yield return null;
+
+            // Assert: 両方表示中
+            Assert.AreEqual(2, _viewProvider.LoadCallCount, "スタック表示で LoadAsync が計 2 回呼ばれること");
+            Assert.IsTrue(_service.HasActivePopup.CurrentValue, "2 枚同時表示中は HasActivePopup が true であること");
+
+            // スタック上（最前面）を閉じる
+            stackedPopup.Resolve(0);
+            yield return new WaitUntil(() => _viewProvider.ReleaseCallCount >= 1);
+
+            // ベースはまだ表示中
+            Assert.IsTrue(_service.HasActivePopup.CurrentValue, "スタック上を閉じてもベースはまだ表示中であること");
+            Assert.AreEqual(1, _viewProvider.ReleaseCallCount, "スタック上の Release のみ 1 回であること");
+
+            // ベースも閉じる
+            basePopup.Resolve(0);
+            yield return new WaitUntil(() => _viewProvider.ReleaseCallCount >= 2);
+
+            // Assert: 全て閉じた
+            Assert.IsFalse(_service.HasActivePopup.CurrentValue, "ベースを閉じると HasActivePopup が false になること");
+            Assert.AreEqual(2, _viewProvider.ReleaseCallCount, "両方 Release されること");
+        }
+
+        // ---------------------------------------------------------------------------
+        // テストケース 9: CloseAllAsync
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// ベース＋スタックの 2 枚表示中に CloseAllAsync を呼び出すと
+        /// 両方閉じ、HasActivePopup が false に、ReleaseCallCount が 2 になること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CloseAllAsync_WithStackedPopups_ClosesAllAndReleasesAll()
+        {
+            // Arrange
+            var basePopup = MockPopupFactory.Create("Base");
+            var stackedPopup = MockPopupFactory.Create("Stacked");
+            _viewProvider.EnqueueInstance(basePopup);
+            _viewProvider.EnqueueInstance(stackedPopup);
+
+            var baseParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                Stack = false,
+            };
+            var stackParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                Stack = true,
+            };
+
+            // Act: 2 枚表示
+            _service.ShowAsync<MockResultPopup, int>(baseParameter).Forget();
+            yield return null;
+
+            _service.ShowAsync<MockResultPopup, int>(stackParameter).Forget();
+            yield return null;
+
+            Assert.AreEqual(2, _viewProvider.LoadCallCount, "2 枚表示されていること");
+
+            // CloseAllAsync で全部閉じる
+            yield return _service.CloseAllAsync().ToCoroutine();
+
+            // Assert
+            Assert.IsFalse(_service.HasActivePopup.CurrentValue, "CloseAllAsync 後は HasActivePopup が false であること");
+            Assert.AreEqual(2, _viewProvider.ReleaseCallCount, "両方 Release されること");
+        }
+
+        // ---------------------------------------------------------------------------
+        // テストケース 10: 暗幕ルーティング
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// MockPopupDimmer を注入した PopupService で、
+        /// ポップアップ表示時に Show が呼ばれ、閉じると Hide が呼ばれること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Dimmer_WhenPopupShownAndClosed_ShowAndHideCalled()
+        {
+            // Arrange
+            var dimmer = new MockPopupDimmer();
+            var viewProvider = new MockPopupViewProvider();
+            var service = new PopupService(viewProvider, dimmer);
+
+            var popup = MockPopupFactory.Create();
+            viewProvider.EnqueueInstance(popup);
+
+            var parameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                Stack = false,
+            };
+
+            // Act: 表示
+            service.ShowAsync<MockResultPopup, int>(parameter).Forget();
+            yield return null;
+
+            // Assert: Show が 1 回呼ばれ、暗幕が表示状態であること
+            Assert.AreEqual(1, dimmer.ShowCallCount, "表示時に Show が呼ばれること");
+            Assert.IsTrue(dimmer.IsVisible, "表示中は暗幕が可視状態であること");
+
+            // ポップアップを閉じる
+            popup.Resolve(0);
+            yield return new WaitUntil(() => viewProvider.ReleaseCallCount >= 1);
+
+            // Assert: Hide が呼ばれ、暗幕が非表示になること
+            Assert.AreEqual(1, dimmer.HideCallCount, "閉じた後に Hide が呼ばれること");
+            Assert.IsFalse(dimmer.IsVisible, "閉じた後は暗幕が非表示であること");
+
+            service.Dispose();
+        }
+
+        /// <summary>
+        /// スタック 2 枚表示中に暗幕タップ（EmitClick）すると
+        /// EnableBackgroundClose=true の最前面のみが閉じ、
+        /// EnableBackgroundClose=false のベースは残ること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator Dimmer_WhenClickedWithStackedPopups_ClosesOnlyTopPopup()
+        {
+            // Arrange
+            var dimmer = new MockPopupDimmer();
+            var viewProvider = new MockPopupViewProvider();
+            var service = new PopupService(viewProvider, dimmer);
+
+            var basePopup = MockPopupFactory.Create("Base");
+            var stackedPopup = MockPopupFactory.Create("Stacked");
+            viewProvider.EnqueueInstance(basePopup);
+            viewProvider.EnqueueInstance(stackedPopup);
+
+            // ベースは背景タップで閉じない設定
+            var baseParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                EnableBackgroundClose = false,
+                Stack = false,
+            };
+            // スタック上は背景タップで閉じる設定
+            var stackParameter = new TestPopupServiceParameter
+            {
+                Priority = PopupPriority.Normal,
+                EnableBackKey = true,
+                EnableBackgroundClose = true,
+                Stack = true,
+            };
+
+            // Act: 2 枚表示
+            service.ShowAsync<MockResultPopup, int>(baseParameter).Forget();
+            yield return null;
+
+            var stackedResult = -999;
+            async UniTaskVoid StartStacked()
+            {
+                stackedResult = await service.ShowAsync<MockResultPopup, int>(stackParameter);
+            }
+
+            StartStacked().Forget();
+            yield return null;
+
+            Assert.AreEqual(2, viewProvider.LoadCallCount, "2 枚表示されていること");
+
+            // 暗幕タップ → 最前面（EnableBackgroundClose=true）のみ閉じる
+            dimmer.EmitClick();
+            yield return new WaitUntil(() => viewProvider.ReleaseCallCount >= 1);
+
+            // Assert: 最前面が閉じ(-1)、ベースはまだ表示中
+            Assert.AreEqual(-1, stackedResult, "暗幕タップで最前面が OnClose(-1) で閉じること");
+            Assert.IsTrue(service.HasActivePopup.CurrentValue, "ベースはまだ表示中であること");
+            Assert.AreEqual(1, viewProvider.ReleaseCallCount, "最前面のみ Release されること");
+
+            // ベースを閉じて後始末
+            basePopup.Resolve(0);
+            yield return new WaitUntil(() => viewProvider.ReleaseCallCount >= 2);
+
+            Assert.IsFalse(service.HasActivePopup.CurrentValue, "ベースを閉じると HasActivePopup が false であること");
+
+            service.Dispose();
+        }
+
+        // ---------------------------------------------------------------------------
+        // テストケース 11: CompositePopupTransition
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// CompositePopupTransition の _transitions にリフレクションで複数の RecordingPopupTransition を注入し、
+        /// PlayOpenAsync / PlayCloseAsync を呼び出すと全子トランジションが 1 回ずつ再生されること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator CompositePopupTransition_PlayOpenAndClose_InvokesAllChildTransitions()
+        {
+            // Arrange
+            var gameObject = new GameObject("CompositeTransitionTest");
+            var composite = gameObject.AddComponent<CompositePopupTransition>();
+
+            var firstRecorder = gameObject.AddComponent<RecordingPopupTransition>();
+            var secondRecorder = gameObject.AddComponent<RecordingPopupTransition>();
+
+            // private SerializeField _transitions にリフレクションで代入する
+            var transitionsField = typeof(CompositePopupTransition).GetField(
+                "_transitions",
+                System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            transitionsField?.SetValue(composite, new PopupTransitionBase[] { firstRecorder, secondRecorder });
+
+            // Act: PlayOpenAsync
+            yield return composite.PlayOpenAsync(CancellationToken.None).ToCoroutine();
+
+            // Assert: 全子が Open を 1 回再生したこと
+            Assert.AreEqual(1, firstRecorder.OpenCallCount, "1 つ目の子トランジションの PlayOpenAsync が 1 回呼ばれること");
+            Assert.AreEqual(1, secondRecorder.OpenCallCount, "2 つ目の子トランジションの PlayOpenAsync が 1 回呼ばれること");
+            Assert.AreEqual(0, firstRecorder.CloseCallCount, "Open 後は Close が呼ばれていないこと");
+
+            // Act: PlayCloseAsync
+            yield return composite.PlayCloseAsync(CancellationToken.None).ToCoroutine();
+
+            // Assert: 全子が Close を 1 回再生したこと
+            Assert.AreEqual(1, firstRecorder.CloseCallCount, "1 つ目の子トランジションの PlayCloseAsync が 1 回呼ばれること");
+            Assert.AreEqual(1, secondRecorder.CloseCallCount, "2 つ目の子トランジションの PlayCloseAsync が 1 回呼ばれること");
+
+            UnityEngine.Object.Destroy(gameObject);
+        }
+
+        // ---------------------------------------------------------------------------
+        // テストケース 12: キャンセル時 Release 保証（回帰）
+        // ---------------------------------------------------------------------------
+
+        /// <summary>
+        /// 表示中の ShowAsync を CancellationTokenSource でキャンセルしたとき、
+        /// OperationCanceledException がスローされ、ReleaseCallCount が 1 になること。
+        /// </summary>
+        [UnityTest]
+        public IEnumerator ShowAsync_CancelledAfterDisplaying_ThrowsCancelledAndReleasesView()
+        {
+            // Arrange
+            var popup = MockPopupFactory.Create();
+            _viewProvider.EnqueueInstance(popup);
+            var parameter = CreateParameter();
+            var cancellationTokenSource = new CancellationTokenSource();
+            Exception caughtException = null;
+            var isCompleted = false;
+
+            // Act
+            async UniTaskVoid StartRequest()
+            {
+                try
+                {
+                    await _service.ShowAsync<MockResultPopup, int>(
+                        parameter, cancellationTokenSource.Token);
+                }
+                catch (OperationCanceledException exception)
+                {
+                    caughtException = exception;
+                }
+                finally
+                {
+                    isCompleted = true;
+                }
+            }
+
+            StartRequest().Forget();
+
+            // 1 フレーム待って表示状態になることを確認する
+            yield return null;
+            Assert.IsTrue(_service.HasActivePopup.CurrentValue, "キャンセル前は表示中であること");
+
+            // キャンセル実行
+            cancellationTokenSource.Cancel();
+
+            // finally の Release 処理が完了するまで待つ
+            yield return new WaitUntil(() => isCompleted);
+
+            // Assert
+            Assert.IsInstanceOf<OperationCanceledException>(caughtException, "キャンセル時に OperationCanceledException がスローされること");
+            Assert.AreEqual(1, _viewProvider.ReleaseCallCount, "キャンセル時も Release が 1 回呼ばれること");
         }
     }
 }

--- a/Assets/UniLab/Sample/Popup/PopupSampleEntry.cs
+++ b/Assets/UniLab/Sample/Popup/PopupSampleEntry.cs
@@ -31,8 +31,10 @@ namespace UniLab.UI.Popup.Sample
 
         private void Awake()
         {
-            // 共通暗幕を注入する。各ポップアップは個別背景を持たず、この 1 枚を最前面ポップアップの背後に共有する
-            _popupService = new PopupService(new ResourcesPopupViewProvider(_popupRoot), _dimmer);
+            // ロード手段は IPopupAssetLoader で差し替え可能。サンプルは Resources 版を使う（本番は AssetVault 版に差し替え）。
+            // 共通暗幕を注入し、各ポップアップは個別背景を持たず 1 枚を最前面ポップアップの背後に共有する
+            var viewProvider = new PopupViewProvider(new ResourcesPopupAssetLoader(), _popupRoot);
+            _popupService = new PopupService(viewProvider, _dimmer);
             // 非 DI 環境のため手動で生成・購読開始する。DI 環境では PopupInstaller が代行する
             _backKeyHandler = new PopupBackKeyHandler(_popupService);
             _backKeyHandler.Start();
@@ -183,46 +185,6 @@ namespace UniLab.UI.Popup.Sample
             _disposables.Dispose();
             _backKeyHandler.Dispose();
             ((IDisposable)_popupService).Dispose();
-        }
-
-        /// <summary>
-        /// Resources からポップアッププレハブをロードする ViewProvider。
-        /// Editor でのプレハブ参照配線を介さず、型名で Resources/Popup/{型名} を解決する。
-        /// </summary>
-        private sealed class ResourcesPopupViewProvider : IPopupViewProvider
-        {
-            private readonly Transform _popupRoot;
-
-            public ResourcesPopupViewProvider(Transform popupRoot)
-            {
-                _popupRoot = popupRoot;
-            }
-
-            public UniTask<TPopup> LoadAsync<TPopup>(CancellationToken cancellationToken) where TPopup : PopupBase
-            {
-                var prefab = Resources.Load<TPopup>($"Popup/{typeof(TPopup).Name}");
-                if (prefab == null)
-                {
-                    throw new InvalidOperationException(
-                        $"Resources/Popup/{typeof(TPopup).Name} が見つかりません。");
-                }
-
-                var instance = UnityEngine.Object.Instantiate(prefab, _popupRoot);
-                instance.gameObject.SetActive(false);
-                return UniTask.FromResult(instance);
-            }
-
-            public void Release(PopupBase popup)
-            {
-                // Play モード停止・シーン破棄で GameObject が先に破棄されると、Unity の == は破棄済みを null 扱いする。
-                // この状態で gameObject へアクセスすると MissingReferenceException になるため、破棄済みなら何もしない
-                if (popup == null)
-                {
-                    return;
-                }
-
-                UnityEngine.Object.Destroy(popup.gameObject);
-            }
         }
     }
 }

--- a/Assets/UniLab/UIComponent/Popup/AssetVault.meta
+++ b/Assets/UniLab/UIComponent/Popup/AssetVault.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fcab7f717c6fd470d866360237453bd9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Popup/AssetVault/AssetVaultPopupAssetLoader.cs
+++ b/Assets/UniLab/UIComponent/Popup/AssetVault/AssetVaultPopupAssetLoader.cs
@@ -1,0 +1,76 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UniLab.AssetVault;
+using UnityEngine;
+
+namespace UniLab.UI.Popup
+{
+    /// <summary>
+    /// AssetVault(Addressables) からポップアップ View をロードする IPopupAssetLoader 実装。
+    /// View ごとに AssetScope を作って生成し、Release でそのスコープを破棄して Addressables ハンドルを確実に解放する。
+    /// 本実装は AssetVault に依存するため、コア（UniLab）とは別アセンブリに置いて依存を隔離する。
+    /// </summary>
+    public sealed class AssetVaultPopupAssetLoader : IPopupAssetLoader
+    {
+        private const string AddressPrefix = "Popup/";
+
+        private readonly IAssetVaultService _assetVaultService;
+
+        // View インスタンスと、その生成に使った AssetScope を参照同一性で対応づける。
+        // ConditionalWeakTable は Unity の == 上書きに影響されず、破棄済み View でも引ける
+        private readonly ConditionalWeakTable<PopupBase, IAssetScope> _scopes = new();
+
+        /// <summary>ロードに用いる AssetVault サービスを注入する。</summary>
+        public AssetVaultPopupAssetLoader(IAssetVaultService assetVaultService)
+        {
+            _assetVaultService = assetVaultService;
+        }
+
+        /// <summary>Popup/{型名} アドレスを専用スコープ経由で生成し、非表示で返す。</summary>
+        public async UniTask<TPopup> InstantiateAsync<TPopup>(Transform parent, CancellationToken cancellationToken)
+            where TPopup : PopupBase
+        {
+            var scope = _assetVaultService.CreateScope();
+            try
+            {
+                var address = $"{AddressPrefix}{typeof(TPopup).Name}";
+                var gameObject = await scope.InstantiateAsync(address, parent, cancellationToken);
+                var popup = gameObject.GetComponent<TPopup>();
+                if (popup == null)
+                {
+                    throw new InvalidOperationException(
+                        $"生成した {address} に {typeof(TPopup).Name} コンポーネントがありません。");
+                }
+
+                popup.gameObject.SetActive(false);
+                _scopes.Add(popup, scope);
+                return popup;
+            }
+            catch
+            {
+                // 生成途中の失敗時もハンドルを取りこぼさないよう、対応スコープを破棄してから送出する
+                scope.Dispose();
+                throw;
+            }
+        }
+
+        /// <summary>View に対応するスコープを破棄し、Addressables インスタンスとハンドルを解放する。</summary>
+        public void Release(PopupBase popup)
+        {
+            // 真の null のみ弾く（破棄済み Unity オブジェクトは参照同一性で引けるのでスコープ解放を続行する）
+            if (popup is null)
+            {
+                return;
+            }
+
+            if (_scopes.TryGetValue(popup, out var scope))
+            {
+                _scopes.Remove(popup);
+                // scope.Dispose() が Addressables.Release を呼び、生成物の破棄とハンドル解放を行う
+                scope.Dispose();
+            }
+        }
+    }
+}

--- a/Assets/UniLab/UIComponent/Popup/AssetVault/AssetVaultPopupAssetLoader.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/AssetVault/AssetVaultPopupAssetLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 524f50961a06446bd978234ae92db26e

--- a/Assets/UniLab/UIComponent/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.asmdef
+++ b/Assets/UniLab/UIComponent/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "UniLab.UIComponent.Popup.AssetVault",
+    "rootNamespace": "",
+    "references": [
+        "UniLab",
+        "UniLab.AssetVault",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/UniLab/UIComponent/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.asmdef.meta
+++ b/Assets/UniLab/UIComponent/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c8142d15d1b2841cf84846ae982544fd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupAssetLoader.cs
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupAssetLoader.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace UniLab.UI.Popup
+{
+    /// <summary>
+    /// ポップアップ View の「ロード手段」を抽象化する。Resources / Addressables(AssetVault) 等の差異をここに閉じ込め、
+    /// PopupViewProvider はこのインターフェースだけに依存する。Release で生成物とロードハンドルの双方を解放する。
+    /// </summary>
+    public interface IPopupAssetLoader
+    {
+        /// <summary>型 TPopup の View を parent 配下に生成し、非表示状態で返す。PopupViewProvider が表示前に呼ぶ。</summary>
+        UniTask<TPopup> InstantiateAsync<TPopup>(Transform parent, CancellationToken cancellationToken)
+            where TPopup : PopupBase;
+
+        /// <summary>生成した View を解放する。生成物の破棄に加え、ロードハンドル / スコープも解放する。</summary>
+        void Release(PopupBase popup);
+    }
+}

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupAssetLoader.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupAssetLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8a26dca44f9ad425f97ab14b16edd8cd

--- a/Assets/UniLab/UIComponent/Popup/Interface/IPopupService.cs
+++ b/Assets/UniLab/UIComponent/Popup/Interface/IPopupService.cs
@@ -21,5 +21,11 @@ namespace UniLab.UI.Popup
 
         /// <summary>表示中のポップアップをバックキー相当で閉じる。表示中でなければ何もしない。</summary>
         UniTask CloseTopAsync();
+
+        /// <summary>
+        /// 表示中の全ポップアップを最前面から順に強制的に閉じ、全て閉じ終わるまで待つ。
+        /// シーン遷移・ログアウト時の一括クローズ用。待機列の未表示要求は対象外。
+        /// </summary>
+        UniTask CloseAllAsync();
     }
 }

--- a/Assets/UniLab/UIComponent/Popup/PopupService.cs
+++ b/Assets/UniLab/UIComponent/Popup/PopupService.cs
@@ -90,6 +90,27 @@ namespace UniLab.UI.Popup
             top.OnClose();
         }
 
+        /// <summary>
+        /// 表示中の全ポップアップを最前面から順に閉じ、全て閉じ終わる（スタックが空になる）まで待つ。
+        /// EnableBackKey に依らず強制クローズする。待機列の未表示要求は対象外。
+        /// </summary>
+        public async UniTask CloseAllAsync()
+        {
+            // OnClose は結果確定のみで、実際の除去は各 PresentAsync の finally で行われる。
+            // よってこのループ中に _stack は変化しない。最前面から順に閉じ要求を出す
+            for (var index = _stack.Count - 1; index >= 0; index--)
+            {
+                var popup = _stack[index];
+                if (popup != null)
+                {
+                    popup.OnClose();
+                }
+            }
+
+            // 全 PresentAsync のクローズ・解放完了（スタックが空）まで待つ
+            await UniTask.WaitWhile(() => _stack.Count > 0);
+        }
+
         /// <summary>暗幕タップ購読と HasActivePopup の購読リソースを破棄する。</summary>
         public void Dispose()
         {

--- a/Assets/UniLab/UIComponent/Popup/Provider/PopupViewProvider.cs
+++ b/Assets/UniLab/UIComponent/Popup/Provider/PopupViewProvider.cs
@@ -1,0 +1,35 @@
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace UniLab.UI.Popup
+{
+    /// <summary>
+    /// IPopupAssetLoader にロードを委譲する汎用 ViewProvider。生成先 PopupRoot を保持し、
+    /// ローダーを差し替えるだけで Resources / Addressables 等の供給手段を切り替えられる。
+    /// </summary>
+    public sealed class PopupViewProvider : IPopupViewProvider
+    {
+        private readonly IPopupAssetLoader _loader;
+        private readonly Transform _popupRoot;
+
+        /// <summary>ロード手段と生成先ルートを注入する。</summary>
+        public PopupViewProvider(IPopupAssetLoader loader, Transform popupRoot)
+        {
+            _loader = loader;
+            _popupRoot = popupRoot;
+        }
+
+        /// <summary>ローダーに委譲して View を生成する。</summary>
+        public UniTask<TPopup> LoadAsync<TPopup>(CancellationToken cancellationToken) where TPopup : PopupBase
+        {
+            return _loader.InstantiateAsync<TPopup>(_popupRoot, cancellationToken);
+        }
+
+        /// <summary>ローダーに委譲して View を解放する。</summary>
+        public void Release(PopupBase popup)
+        {
+            _loader.Release(popup);
+        }
+    }
+}

--- a/Assets/UniLab/UIComponent/Popup/Provider/PopupViewProvider.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Provider/PopupViewProvider.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 01e91657c1a1e4c3caf2cbfa640790f7

--- a/Assets/UniLab/UIComponent/Popup/Provider/ResourcesPopupAssetLoader.cs
+++ b/Assets/UniLab/UIComponent/Popup/Provider/ResourcesPopupAssetLoader.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace UniLab.UI.Popup
+{
+    /// <summary>
+    /// Resources からポップアップ View をロードする IPopupAssetLoader 実装。
+    /// パスは型名規約 Resources/Popup/{型名}。Addressables 非依存で、小規模・組み込み用途向け。
+    /// </summary>
+    public sealed class ResourcesPopupAssetLoader : IPopupAssetLoader
+    {
+        private const string ResourcePathPrefix = "Popup/";
+
+        /// <summary>Resources/Popup/{型名} をロードして生成し、非表示で返す。見つからなければ例外を投げる。</summary>
+        public UniTask<TPopup> InstantiateAsync<TPopup>(Transform parent, CancellationToken cancellationToken)
+            where TPopup : PopupBase
+        {
+            var prefab = Resources.Load<TPopup>($"{ResourcePathPrefix}{typeof(TPopup).Name}");
+            if (prefab == null)
+            {
+                throw new InvalidOperationException(
+                    $"Resources/{ResourcePathPrefix}{typeof(TPopup).Name} が見つかりません。");
+            }
+
+            var instance = UnityEngine.Object.Instantiate(prefab, parent);
+            instance.gameObject.SetActive(false);
+            return UniTask.FromResult(instance);
+        }
+
+        /// <summary>生成物を破棄する。Play モード停止等で既に破棄済みなら何もしない。</summary>
+        public void Release(PopupBase popup)
+        {
+            // Unity の == は破棄済みを null 扱いする。破棄済みアクセスで MissingReferenceException になるため弾く
+            if (popup == null)
+            {
+                return;
+            }
+
+            UnityEngine.Object.Destroy(popup.gameObject);
+        }
+    }
+}

--- a/Assets/UniLab/UIComponent/Popup/Provider/ResourcesPopupAssetLoader.cs.meta
+++ b/Assets/UniLab/UIComponent/Popup/Provider/ResourcesPopupAssetLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 286e4c36f65144aa9944a154ae3bec00


### PR DESCRIPTION
## Summary

- IPopupAssetLoader インターフェースによるロード手段の抽象化。PopupViewProvider は依存性をインジェクション形式に変更
- Resources/AssetVault 別実装で複数のアセット管理戦略に対応
- PopupService に CloseAllAsync を追加。シーン遷移・ログアウト時の一括クローズが可能に
- スタック同時表示・暗幕ルーティング・複合Transition・キャンセル時解放のテストカバーを拡充

## Changes

- **feat: Popup の ViewProvider をロード手段抽象 IPopupAssetLoader に分離し Resources/AssetVault 実装を追加**
  - IPopupAssetLoader インターフェース新規追加
  - PopupViewProvider の依存性をロード手段に変更
  - ResourcesPopupAssetLoader による Resources ロード実装
  - AssetVaultPopupAssetLoader による AssetVault ロード実装
  - PopupSampleEntry をロード手段抽象に対応

- **feat: PopupService に CloseAllAsync（全ポップアップ一括クローズ）を追加**
  - IPopupService に CloseAllAsync シグネチャ追加
  - PopupService で全スタック上のポップアップを最前面から順に閉じ実装
  - 待機列未表示要求は対象外

- **test: Popup のスタック表示・暗幕・複合Transition・キャンセル時解放のテストを追加**
  - テストダブル: MockPopupDimmer（暗幕クリックイベント発火・Show/Hide 呼び出し記録）
  - テストダブル: RecordingPopupTransition（Open/Close 呼び出し回数記録）
  - テストケース 8: スタック同時表示（Stack=false ベース + Stack=true 重ね層）
  - テストケース 9: CloseAllAsync による全閉じ
  - テストケース 10: 暗幕ルーティング（表示時 Show・閉じ時 Hide）
  - テストケース 11: CompositePopupTransition 全子トランジション実行
  - テストケース 12: キャンセル時 Release 保証

🤖 Generated with [Claude Code](https://claude.com/claude-code)