### PR TITLE
Popup AssetVault ロード検証サンプルを追加

### DIFF
--- a/Assets/UniLab/Sample/Popup/AssetVault.meta
+++ b/Assets/UniLab/Sample/Popup/AssetVault.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 819977e4123fb40449cefb607377c7c1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/UniLab/Sample/Popup/AssetVault/PopupAssetVaultSampleEntry.cs
+++ b/Assets/UniLab/Sample/Popup/AssetVault/PopupAssetVaultSampleEntry.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using R3;
+using UniLab.AssetVault;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace UniLab.UI.Popup.AssetVaultSample
+{
+    /// <summary>
+    /// AssetVault(Addressables) 経由で Popup をロードする検証用サンプル。
+    /// ローカル初期化（baseUrl 空）で AddressablesAssetVaultService を起動し、AssetVaultPopupAssetLoader で表示する。
+    /// 事前に ConfirmPopup プレハブを Addressable 化し、アドレス "Popup/ConfirmPopup" を付与しておくこと。
+    /// </summary>
+    public sealed class PopupAssetVaultSampleEntry : MonoBehaviour
+    {
+        [SerializeField] private Transform _popupRoot = null;
+        [SerializeField] private PopupDimmer _dimmer = null;
+        [SerializeField] private Button _showButton = null;
+
+        // 自己完結サンプルのため new。実プロジェクトでは IAssetVaultService をコンストラクタ注入する
+        private readonly AddressablesAssetVaultService _assetVaultService = new();
+        private IPopupService _popupService = null;
+        private readonly CompositeDisposable _disposables = new();
+
+        private void Start()
+        {
+            RunAsync(destroyCancellationToken).Forget();
+        }
+
+        private async UniTask RunAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                // Local 専用: baseUrl 空で version 解決・ダウンロードをスキップする
+                await _assetVaultService.InitializeAsync(string.Empty, cancellationToken);
+
+                // ロード手段を AssetVault 版に差し替えるだけ。表示・スタック・暗幕の挙動はコアと共通
+                var viewProvider = new PopupViewProvider(
+                    new AssetVaultPopupAssetLoader(_assetVaultService), _popupRoot);
+                _popupService = new PopupService(viewProvider, _dimmer);
+
+                _showButton.OnClickAsObservable()
+                    .Subscribe(_ => ShowConfirmAsync(destroyCancellationToken).Forget())
+                    .AddTo(_disposables);
+            }
+            catch (OperationCanceledException)
+            {
+                // 画面破棄による正常キャンセル
+            }
+            catch (AssetVaultException exception)
+            {
+                Debug.LogError(exception);
+            }
+        }
+
+        private async UniTask ShowConfirmAsync(CancellationToken cancellationToken)
+        {
+            // アドレス "Popup/ConfirmPopup" を AssetVault がロード → AssetScope に紐づけ → 閉じたら Dispose で解放
+            var result = await _popupService.ShowAsync<ConfirmPopup, PopupResult>(
+                new PopupParameter
+                {
+                    Title = "AssetVault",
+                    Message = "Loaded via Addressables.",
+                    ConfirmLabel = "OK",
+                    CancelLabel = "Cancel",
+                },
+                cancellationToken);
+
+            Debug.Log($"[Popup/AssetVault] result: {result}");
+        }
+
+        private void OnDestroy()
+        {
+            _disposables.Dispose();
+            // 初期化完了前に破棄され得るため null を確認する
+            if (_popupService != null)
+            {
+                ((IDisposable)_popupService).Dispose();
+            }
+
+            _assetVaultService.Dispose();
+        }
+    }
+}

--- a/Assets/UniLab/Sample/Popup/AssetVault/PopupAssetVaultSampleEntry.cs.meta
+++ b/Assets/UniLab/Sample/Popup/AssetVault/PopupAssetVaultSampleEntry.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8c88486c41d9a419c9cf09f3f354056e

--- a/Assets/UniLab/Sample/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.Sample.asmdef
+++ b/Assets/UniLab/Sample/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.Sample.asmdef
@@ -1,0 +1,21 @@
+{
+    "name": "UniLab.UIComponent.Popup.AssetVault.Sample",
+    "rootNamespace": "",
+    "references": [
+        "UniLab",
+        "UniLab.AssetVault",
+        "UniLab.UIComponent.Popup.AssetVault",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:77221876cc6b8244180b96e320b1bcd4",
+        "UnityEngine.UI"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/UniLab/Sample/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.Sample.asmdef.meta
+++ b/Assets/UniLab/Sample/Popup/AssetVault/UniLab.UIComponent.Popup.AssetVault.Sample.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8f4c946211b99400683c2da3920c4f00
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 概要

Popup v2 の AssetVault ロード経路を実装・検証するためのサンプルを追加しました。

## 変更内容

- `PopupAssetVaultSampleEntry.cs`: AssetVault 経由での Popup ロード・表示・クローズ動作確認用の Entry point
- `UniLab.UIComponent.Popup.AssetVault.Sample.asmdef`: サンプル専用の Assembly Definition

## テスト手順

1. `Assets/UniLab/Sample/Popup/Resources/Popup/ConfirmPopup.prefab` を選択し、Inspector で Addressable をオン化
2. アドレスを `Popup/ConfirmPopup` に設定
3. Play Mode Script を「Use Asset Database (fastest)」へ変更
4. Play モード実行で ConfirmPopup がロード・表示・クローズされることを確認

詳細は `docs/design-unilab-popup-v2.md` の「実装追補」セクションを参照してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)