### PR TITLE
Editor 拡張の表示文字列・Debug.Log を英語化

### DIFF
--- a/Assets/UniLab/AssetVault/Editor/AssetVaultDebugEnvironmentSettingsEditor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultDebugEnvironmentSettingsEditor.cs
@@ -13,10 +13,11 @@ namespace UniLab.AssetVault.Editor
     public sealed class AssetVaultDebugEnvironmentSettingsEditor : UnityEditor.Editor
     {
         private const string PresetsPropertyName = "_presets";
+        // デバッグ環境プリセットの編集方法と適用範囲を説明するヘルプ文言。
         private const string HelpMessage =
-            "デバッグ環境プリセット（表示名・BaseUrl）を編集します。BaseUrl のみ上書きし、ContentPath（版）は version.json 解決に任せます。\n"
-            + "有効化・選択は UI からは行えません。コードから AssetVaultDebugEnvironmentSettings.Activate(\"<名前>\") / Deactivate() を呼んでください。\n"
-            + "Editor Play と development ビルドでのみ適用され、release ビルドではコードごとストリップされます。";
+            "Edit debug environment presets (display name and BaseUrl). Only BaseUrl is overridden; ContentPath (version) is resolved from version.json.\n"
+            + "Activation and selection cannot be done from the UI. Call AssetVaultDebugEnvironmentSettings.Activate(\"<name>\") / Deactivate() from code.\n"
+            + "Applied only in Editor Play and development builds; the code is stripped entirely from release builds.";
 
         private SerializedProperty _presetsProperty;
 
@@ -55,16 +56,19 @@ namespace UniLab.AssetVault.Editor
             {
                 if (string.IsNullOrEmpty(preset.DisplayName))
                 {
-                    issues.Add("表示名が空のプリセットがあります。");
+                    // 表示名が空のプリセットがある。
+                    issues.Add("A preset has an empty display name.");
                 }
                 else if (!seenNames.Add(preset.DisplayName))
                 {
-                    issues.Add($"表示名が重複しています: {preset.DisplayName}");
+                    // 表示名が重複している。
+                    issues.Add($"Duplicate display name: {preset.DisplayName}");
                 }
 
                 if (string.IsNullOrEmpty(preset.BaseUrl))
                 {
-                    issues.Add($"BaseUrl が空です: {(string.IsNullOrEmpty(preset.DisplayName) ? "(無名)" : preset.DisplayName)}");
+                    // BaseUrl が空である。
+                    issues.Add($"BaseUrl is empty: {(string.IsNullOrEmpty(preset.DisplayName) ? "(unnamed)" : preset.DisplayName)}");
                 }
             }
 

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultDebugMenu.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultDebugMenu.cs
@@ -13,7 +13,8 @@ namespace UniLab.AssetVault.Editor
         private const string SelectMenuPath = "UniLab/AssetVault/Debug/Select Environment...";
         private const string DisableMenuPath = "UniLab/AssetVault/Debug/Disable Override";
         private const string DisableItemLabel = "Disable Override";
-        private const string NoPresetsMessage = "プリセットが未登録です。Dashboard の Edit Presets から追加してください。";
+        // プリセット未登録時の警告。Dashboard の Edit Presets から追加するよう促す。
+        private const string NoPresetsMessage = "No presets registered. Add one from Edit Presets in the Dashboard.";
 
         /// <summary>
         /// 登録済みプリセットをドロップダウンで提示し、選んだものを有効化します。

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultDuplicateAddressCollector.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultDuplicateAddressCollector.cs
@@ -8,7 +8,8 @@ namespace UniLab.AssetVault.Editor
     /// </summary>
     internal sealed class AssetVaultDuplicateAddressCollector
     {
-        private const string DuplicateAddressLineFormat = "重複アドレス: {0}（{1} と {2}）";
+        // 重複アドレスのレポート1行。{0}=アドレス, {1}=最初のアセット, {2}=重複したアセット。
+        private const string DuplicateAddressLineFormat = "Duplicate address: {0} ({1} and {2})";
 
         private readonly Dictionary<string, string> _registeredAssetPathsByAddress = new();
         private readonly List<DuplicateAddress> _duplicateAddresses = new();

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettings.cs
@@ -14,13 +14,16 @@ namespace UniLab.AssetVault.Editor
         /// </summary>
         public const string AssetPath = GeneratedAssetFolder.Path + "/AssetVaultSetupSettings.asset";
 
-        [Tooltip("同梱(Local)アセットのルートフォルダ。【必須】直下サブフォルダがグループ Local_<名> になります。")]
+        // 同梱(Local)アセットのルートフォルダ。【必須】直下サブフォルダがグループ Local_<名> になる。
+        [Tooltip("Root folder for bundled (Local) assets. [Required] Each direct subfolder becomes group Local_<name>.")]
         [SerializeField] private DefaultAsset _localFolder;
 
-        [Tooltip("CDN(Remote)アセットのルートフォルダ。【任意】未設定可。直下サブフォルダがグループ Remote_<名> になります。")]
+        // CDN(Remote)アセットのルートフォルダ。【任意】未設定可。直下サブフォルダがグループ Remote_<名> になる。
+        [Tooltip("Root folder for CDN (Remote) assets. [Optional] Each direct subfolder becomes group Remote_<name>.")]
         [SerializeField] private DefaultAsset _remoteFolder;
 
-        [Tooltip("オンにすると Local/Remote 配下のアセット追加・移動・削除を検知して Addressables を自動登録/更新します。既定オフ。")]
+        // オンにすると Local/Remote 配下のアセット追加・移動・削除を検知して Addressables を自動登録/更新する。既定オフ。
+        [Tooltip("When enabled, additions/moves/deletions under Local/Remote are detected and Addressables entries are auto-registered/updated. Off by default.")]
         [SerializeField] private bool _autoRegisterOnAssetChange;
 
         /// <summary>

--- a/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
+++ b/Assets/UniLab/AssetVault/Editor/AssetVaultSetupSettingsEditor.cs
@@ -13,18 +13,21 @@ namespace UniLab.AssetVault.Editor
     {
         private const string LocalFolderPropertyName = "_localFolder";
         private const string RemoteFolderPropertyName = "_remoteFolder";
+        // Sync AssetResource が走査するルートフォルダの説明。スロットが Local/Remote を決め、フォルダ名は分類に影響しない。
         private const string HelpMessage =
-            "Sync AssetResource が走査するルートフォルダを指定します。\n"
-            + "・Local Folder【必須】: プレイヤー同梱。直下サブフォルダ → グループ Local_<名>\n"
-            + "・Remote Folder【任意】: CDN 配信。直下サブフォルダ → グループ Remote_<名>\n"
-            + "フォルダ名は分類に影響しません（スロット自体が Local/Remote を決めます）。フォルダを指定して下のボタンで同期します。";
+            "Specify the root folders that Sync AssetResource scans.\n"
+            + "- Local Folder [Required]: bundled with the player. Direct subfolder -> group Local_<name>\n"
+            + "- Remote Folder [Optional]: served from CDN. Direct subfolder -> group Remote_<name>\n"
+            + "Folder names do not affect classification (the slot itself decides Local/Remote). Assign folders, then sync with the button below.";
 
-        private const string LocalMissingMessage = "Local Folder が未設定です。Local は必須のため、フォルダを指定するまで Sync できません。";
-        private const string LocalNotFolderMessage = "Local Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
-        private const string RemoteNotFolderMessage = "Remote Folder にフォルダ以外が割り当てられています。フォルダを指定してください。";
-        private const string OverlapMessage = "Local と Remote は別フォルダにしてください（同一・入れ子は二重登録やアドレス衝突を招きます）。";
-        private const string AutoRegisterEnabledMessage = "自動登録が有効です。Local/Remote 配下の追加・移動・削除は Addressables へ差分反映されます。厳密な重複検出や全体掃除が必要な場合は Sync AssetResource を実行してください。";
-        private const string AutoRegisterDisabledMessage = "自動登録はオフです。Local/Remote 配下の変更は、下の Sync AssetResource を実行して反映してください。";
+        // Local 未設定の警告。Local は必須のためフォルダ指定まで Sync 不可。
+        private const string LocalMissingMessage = "Local Folder is not set. Local is required, so you cannot sync until a folder is assigned.";
+        private const string LocalNotFolderMessage = "Local Folder is assigned a non-folder asset. Please assign a folder.";
+        private const string RemoteNotFolderMessage = "Remote Folder is assigned a non-folder asset. Please assign a folder.";
+        // 同一・入れ子は二重登録やアドレス衝突を招くため、別フォルダを要求する。
+        private const string OverlapMessage = "Local and Remote must be different folders (identical or nested folders cause duplicate registration and address collisions).";
+        private const string AutoRegisterEnabledMessage = "Auto-registration is on. Additions/moves/deletions under Local/Remote are incrementally reflected to Addressables. Run Sync AssetResource when you need strict duplicate detection or a full cleanup.";
+        private const string AutoRegisterDisabledMessage = "Auto-registration is off. Run Sync AssetResource below to reflect changes under Local/Remote.";
 
         public override void OnInspectorGUI()
         {

--- a/Assets/UniLab/Localization/Editor/LocalizationAssetPostprocessor.cs
+++ b/Assets/UniLab/Localization/Editor/LocalizationAssetPostprocessor.cs
@@ -28,7 +28,8 @@ namespace UniLab.Localization.Editor
                 TextManager.ResetLoadedAsset();
                 LocalizedTextUpdater.UpdateAllLocalizedTexts();
                 _lastProcessedTime = now;
-                Debug.Log("LocalizationData.asset インポート後に LocalizedText を更新しました。");
+                // LocalizationData.asset インポート後に LocalizedText を更新した旨のログ
+                Debug.Log("Updated LocalizedText after importing LocalizationData.asset.");
             }
         }
     }

--- a/Assets/UniLab/MasterData/Editor/MasterLocalViewer.cs
+++ b/Assets/UniLab/MasterData/Editor/MasterLocalViewer.cs
@@ -109,20 +109,21 @@ namespace UniLab.MasterData.Editor
 
             if (_key == null || _iv == null)
             {
-                _status = "aes_key.txt が見つかりませんでした。マスター出力時に鍵を保存してください。";
+                // aes_key.txt が無い場合はマスター出力時に鍵を保存するよう促す
+                _status = "aes_key.txt not found. Please save the key when exporting masters.";
                 return;
             }
 
             var dir = adapter.SavePath;
             if (string.IsNullOrWhiteSpace(dir))
             {
-                _status = "SavePath が空です。";
+                _status = "SavePath is empty.";
                 return;
             }
 
             if (!Directory.Exists(dir))
             {
-                _status = $"SavePath が存在しません: {dir}";
+                _status = $"SavePath does not exist: {dir}";
                 return;
             }
 

--- a/Assets/UniLab/Persistence/Editor/UniLabPlayerPrefsEditorWindow.cs
+++ b/Assets/UniLab/Persistence/Editor/UniLabPlayerPrefsEditorWindow.cs
@@ -35,7 +35,7 @@ namespace UniLab.Persistence.Editor
         /// <summary>
         /// Opens the UniLab PlayerPrefs management window.
         /// </summary>
-        [MenuItem("UniLab/PlayerPrefs/管理")]
+        [MenuItem("UniLab/PlayerPrefs/Manage")]
         public static void ShowWindow()
         {
             GetWindow<UniLabPlayerPrefsEditorWindow>("UniLab PlayerPrefs");
@@ -58,7 +58,7 @@ namespace UniLab.Persistence.Editor
 
         private void OnGUI()
         {
-            EditorGUILayout.HelpBox("保存済みのPlayerPrefsを管理します。", MessageType.Info);
+            EditorGUILayout.HelpBox("Manage saved PlayerPrefs.", MessageType.Info);
             EditorGUILayout.Space();
 
             DrawDeleteAllSection();
@@ -74,11 +74,11 @@ namespace UniLab.Persistence.Editor
         {
             using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
-                EditorGUILayout.LabelField("全削除", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField("Delete All", EditorStyles.boldLabel);
 
-                if (GUILayout.Button("PlayerPrefs をすべて削除"))
+                if (GUILayout.Button("Delete All PlayerPrefs"))
                 {
-                    if (!EditorUtility.DisplayDialog("確認", "PlayerPrefs をすべて削除します。よろしいですか？", "削除", "キャンセル"))
+                    if (!EditorUtility.DisplayDialog("Confirm", "Delete all PlayerPrefs. Are you sure?", "Delete", "Cancel"))
                     {
                         return;
                     }
@@ -94,14 +94,14 @@ namespace UniLab.Persistence.Editor
         {
             using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
             {
-                EditorGUILayout.LabelField("キー指定削除", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField("Delete by Key", EditorStyles.boldLabel);
                 _targetKey = EditorGUILayout.TextField("Key", _targetKey);
 
                 using (new EditorGUI.DisabledScope(string.IsNullOrWhiteSpace(_targetKey)))
                 {
-                    if (GUILayout.Button("入力した Key を削除"))
+                    if (GUILayout.Button("Delete Entered Key"))
                     {
-                        if (!EditorUtility.DisplayDialog("確認", $"PlayerPrefs のキー \"{_targetKey}\" を削除します。よろしいですか？", "削除", "キャンセル"))
+                        if (!EditorUtility.DisplayDialog("Confirm", $"Delete PlayerPrefs key \"{_targetKey}\". Are you sure?", "Delete", "Cancel"))
                         {
                             return;
                         }
@@ -120,9 +120,9 @@ namespace UniLab.Persistence.Editor
             {
                 using (new EditorGUILayout.HorizontalScope())
                 {
-                    EditorGUILayout.LabelField("既知のキー", EditorStyles.boldLabel);
+                    EditorGUILayout.LabelField("Known Keys", EditorStyles.boldLabel);
 
-                    if (GUILayout.Button("再読込", GUILayout.Width(RefreshButtonWidth)))
+                    if (GUILayout.Button("Reload", GUILayout.Width(RefreshButtonWidth)))
                     {
                         InvalidateCache();
                     }
@@ -131,7 +131,7 @@ namespace UniLab.Persistence.Editor
                 var keys = GetKeys();
                 if (keys.Count == 0)
                 {
-                    EditorGUILayout.LabelField("キーは見つかりませんでした。");
+                    EditorGUILayout.LabelField("No keys found.");
                     return;
                 }
 
@@ -149,13 +149,13 @@ namespace UniLab.Persistence.Editor
             using (new EditorGUILayout.HorizontalScope())
             {
                 EditorGUILayout.SelectableLabel(key, GUILayout.Height(EditorGUIUtility.singleLineHeight));
-                GUILayout.Label(PlayerPrefs.HasKey(key) ? "保存済み" : "未保存", GUILayout.Width(StatusLabelWidth));
+                GUILayout.Label(PlayerPrefs.HasKey(key) ? "Saved" : "Not Saved", GUILayout.Width(StatusLabelWidth));
 
                 using (new EditorGUI.DisabledScope(!PlayerPrefs.HasKey(key)))
                 {
-                    if (GUILayout.Button("削除", GUILayout.Width(DeleteButtonWidth)))
+                    if (GUILayout.Button("Delete", GUILayout.Width(DeleteButtonWidth)))
                     {
-                        if (!EditorUtility.DisplayDialog("確認", $"PlayerPrefs のキー \"{key}\" を削除します。よろしいですか？", "削除", "キャンセル"))
+                        if (!EditorUtility.DisplayDialog("Confirm", $"Delete PlayerPrefs key \"{key}\". Are you sure?", "Delete", "Cancel"))
                         {
                             return;
                         }

--- a/Assets/UniLab/Sample/Popup/Editor/PopupSampleBuilder.cs
+++ b/Assets/UniLab/Sample/Popup/Editor/PopupSampleBuilder.cs
@@ -44,7 +44,8 @@ namespace UniLab.UI.Popup.SampleEditor
 
             AssetDatabase.SaveAssets();
             AssetDatabase.Refresh();
-            Debug.Log("[PopupSample] シーンとプレハブを生成しました: " + ScenePath);
+            // シーンとプレハブを生成した旨のログ
+            Debug.Log("[PopupSample] Generated scene and prefabs: " + ScenePath);
         }
 
         private static void CreateConfirmPrefab()

--- a/Assets/UniLab/Sample/Popup/RewardPopup.cs
+++ b/Assets/UniLab/Sample/Popup/RewardPopup.cs
@@ -20,7 +20,8 @@ namespace UniLab.UI.Popup.Sample
             _titleText.text = "Reward!";
             _rewardText.text = $"{parameter.RewardName} x{parameter.Amount}";
 
-            Debug.Log($"[Popup] Reward 表示: priority={parameter.Priority}");
+            // Reward ポップアップ表示時のログ
+            Debug.Log($"[Popup] Reward shown: priority={parameter.Priority}");
 
             _claimButton.OnClickAsObservable()
                 .Subscribe(_ => SetResult(new RewardPopupResult(true, parameter.Amount)))

--- a/Assets/UniLab/SceneManager/Editor/SceneNameEnumGenerator.cs
+++ b/Assets/UniLab/SceneManager/Editor/SceneNameEnumGenerator.cs
@@ -20,7 +20,7 @@ namespace UnityCore.Scene.Editor
             var scenesFolder = ScenesFolder;
             if (!Directory.Exists(scenesFolder))
             {
-                Debug.LogError($"Scenesフォルダが見つかりません: {scenesFolder}");
+                Debug.LogError($"Scenes folder not found: {scenesFolder}");
                 return;
             }
 
@@ -36,7 +36,8 @@ namespace UnityCore.Scene.Editor
                 .ToArray();
             var buildScenes = scenePaths.Select(path => new EditorBuildSettingsScene(path, true)).ToArray();
             EditorBuildSettings.scenes = buildScenes;
-            Debug.Log("Build Settings に全シーンを登録しました。");
+            // Build Settings に全シーンを登録した旨のログ
+            Debug.Log("Registered all scenes to Build Settings.");
 
             var usedNames = new Dictionary<string, int>();
             var enumEntries = sceneFiles.Select(originalName =>
@@ -67,7 +68,7 @@ namespace {Namespace}
             Directory.CreateDirectory(Path.GetDirectoryName(OutputPath) ?? string.Empty);
             File.WriteAllText(OutputPath, code);
             AssetDatabase.Refresh();
-            Debug.Log("SceneNames.cs を自動生成しました。");
+            Debug.Log("Generated SceneNames.cs.");
         }
 
         [MenuItem("UniLab/Scene/SceneName Enum Generator")]
@@ -100,22 +101,22 @@ namespace {Namespace}
 
         private void OnGUI()
         {
-            GUILayout.Label("Scenes フォルダを指定してください", EditorStyles.boldLabel);
+            GUILayout.Label("Specify the Scenes folder", EditorStyles.boldLabel);
             _scenesFolderAsset = (DefaultAsset)EditorGUILayout.ObjectField("Scenes Folder", _scenesFolderAsset, typeof(DefaultAsset), false);
 
             if (_scenesFolderAsset != null)
             {
                 var path = AssetDatabase.GetAssetPath(_scenesFolderAsset);
-                if (GUILayout.Button("保存"))
+                if (GUILayout.Button("Save"))
                 {
                     SceneNamesEnumGenerator.SetScenesFolder(path);
-                    EditorUtility.DisplayDialog("保存", "ScenesFolder のパスを保存しました", "OK");
+                    EditorUtility.DisplayDialog("Save", "Saved the ScenesFolder path", "OK");
                 }
             }
 
             GUILayout.Space(10);
 
-            if (GUILayout.Button("SceneNames.cs を生成"))
+            if (GUILayout.Button("Generate SceneNames.cs"))
             {
                 SceneNamesEnumGenerator.Generate();
             }

--- a/Assets/UniLab/Tools/Editor/AssetReferenceFinder/AssetReferenceFinderSettingsEditor.cs
+++ b/Assets/UniLab/Tools/Editor/AssetReferenceFinder/AssetReferenceFinderSettingsEditor.cs
@@ -28,7 +28,8 @@ namespace UniLab.Tools.Editor.AssetReferenceFinder
 
             EditorGUILayout.Space(6);
 
-            EditorGUILayout.LabelField("Project 背景色", EditorStyles.boldLabel);
+            // Project 背景色
+            EditorGUILayout.LabelField("Project Background Color", EditorStyles.boldLabel);
             EditorGUI.BeginChangeCheck();
             var nextColor = EditorGUILayout.ColorField(EditorToolLabels.Get(LabelKey.ReferenceColorLabel), settings.ProjectReferenceBackgroundColor);
             if (EditorGUI.EndChangeCheck())

--- a/Assets/UniLab/Tools/Editor/AssetReferenceFinder/ProjectAssetReferenceFinderWindow.cs
+++ b/Assets/UniLab/Tools/Editor/AssetReferenceFinder/ProjectAssetReferenceFinderWindow.cs
@@ -98,7 +98,8 @@ namespace UniLab.Tools.Editor.AssetReferenceFinder
 
             if (!CanScanTarget())
             {
-                EditorGUILayout.HelpBox("Project 内のアセットを 1 つ以上指定してください。", MessageType.Info);
+                // Project 内のアセットを 1 つ以上指定してください。
+                EditorGUILayout.HelpBox("Please specify at least one asset from the Project.", MessageType.Info);
             }
 
             using (new EditorGUI.DisabledScope(_isScanning || !CanScanTarget()))
@@ -120,7 +121,8 @@ namespace UniLab.Tools.Editor.AssetReferenceFinder
 
             EditorGUILayout.Space(6);
 
-            EditorGUILayout.LabelField($"参照元数: {_totalReferenceCount}");
+            // 参照元数
+            EditorGUILayout.LabelField($"References: {_totalReferenceCount}");
 
             // --- CSV export ---
             if (_totalReferenceCount > 0)
@@ -299,7 +301,7 @@ namespace UniLab.Tools.Editor.AssetReferenceFinder
                 }
 
                 EditorGUILayout.Space(4);
-                EditorGUILayout.LabelField($"[{Path.GetFileName(targetPath)}]  ({referencePaths.Count} 件)", EditorStyles.boldLabel);
+                EditorGUILayout.LabelField($"[{Path.GetFileName(targetPath)}]  ({referencePaths.Count})", EditorStyles.boldLabel);
                 EditorGUILayout.LabelField(targetPath, EditorStyles.miniLabel);
 
                 for (int i = 0; i < referencePaths.Count; i++)

--- a/Assets/UniLab/Tools/Editor/ComponentUsageProfiler/ComponentUsageProfilerWindow.cs
+++ b/Assets/UniLab/Tools/Editor/ComponentUsageProfiler/ComponentUsageProfilerWindow.cs
@@ -126,8 +126,9 @@ namespace UniLab.Tools.Editor.ComponentUsageProfiler
             }
 
             EditorGUILayout.Space(4);
+            // チェック対象 / 使用中 / 未使用
             EditorGUILayout.LabelField(
-                $"チェック対象: {_allEntries.Count}  使用中: {_usedEntries.Count}  未使用: {_unusedEntries.Count}");
+                $"Checked: {_allEntries.Count}  Used: {_usedEntries.Count}  Unused: {_unusedEntries.Count}");
         }
 
         private void DrawExportButton()
@@ -205,7 +206,8 @@ namespace UniLab.Tools.Editor.ComponentUsageProfiler
                 isExpanded = false;
             }
 
-            var label = entry.TypeName + "  (" + entry.Locations.Count + " 箇所)";
+            // (○箇所) = 配置箇所数
+            var label = entry.TypeName + "  (" + entry.Locations.Count + " locations)";
             var newExpanded = EditorGUILayout.Foldout(isExpanded, label, true);
             _foldoutStates[entry.ScriptPath] = newExpanded;
 
@@ -240,7 +242,8 @@ namespace UniLab.Tools.Editor.ComponentUsageProfiler
 
             if (entry.Locations.Count > MaxVisibleLocations)
             {
-                EditorGUILayout.LabelField($"... 他 {entry.Locations.Count - MaxVisibleLocations} 件", EditorStyles.miniLabel);
+                // 表示上限を超えた残り件数
+                EditorGUILayout.LabelField($"... and {entry.Locations.Count - MaxVisibleLocations} more", EditorStyles.miniLabel);
             }
 
             EditorGUI.indentLevel--;

--- a/Assets/UniLab/Tools/Editor/MissingChecker/ProjectMissingCheckerSettingsEditor.cs
+++ b/Assets/UniLab/Tools/Editor/MissingChecker/ProjectMissingCheckerSettingsEditor.cs
@@ -21,16 +21,18 @@ namespace UniLab.Tools.Editor.MissingChecker
             EditorGUILayout.PropertyField(serializedObject.FindProperty("_extensionsCsv"), GUIContent.none);
             EditorGUILayout.Space(6);
 
-            EditorGUILayout.LabelField("Project 背景色", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_projectSelfBackgroundColor"), new GUIContent("Missing 自身"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_projectParentBackgroundColor"), new GUIContent("親フォルダ"));
+            // Project 背景色
+            EditorGUILayout.LabelField("Project Background Color", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_projectSelfBackgroundColor"), new GUIContent("Missing Itself"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_projectParentBackgroundColor"), new GUIContent("Parent Folder"));
             EditorGUILayout.Space(6);
 
-            EditorGUILayout.LabelField("ヒエラルキー", EditorStyles.boldLabel);
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_enableHierarchyHighlight"), new GUIContent("色付けを有効"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchySelfBackgroundColor"), new GUIContent("Missing 自身"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchyParentBackgroundColor"), new GUIContent("親"));
-            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchyIconColor"), new GUIContent("アイコン色"));
+            // ヒエラルキー
+            EditorGUILayout.LabelField("Hierarchy", EditorStyles.boldLabel);
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_enableHierarchyHighlight"), new GUIContent("Enable Highlight"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchySelfBackgroundColor"), new GUIContent("Missing Itself"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchyParentBackgroundColor"), new GUIContent("Parent"));
+            EditorGUILayout.PropertyField(serializedObject.FindProperty("_hierarchyIconColor"), new GUIContent("Icon Color"));
 
             if (serializedObject.ApplyModifiedProperties())
             {

--- a/Assets/UniLab/Tools/Editor/MissingChecker/ProjectMissingCheckerWindow.cs
+++ b/Assets/UniLab/Tools/Editor/MissingChecker/ProjectMissingCheckerWindow.cs
@@ -77,7 +77,8 @@ namespace UniLab.Tools.Editor.MissingChecker
             }
 
             EditorGUILayout.Space(6);
-            EditorGUILayout.LabelField($"Missing 検出数: {_missingEntries.Count}");
+            // Missing 検出数
+            EditorGUILayout.LabelField($"Missing Found: {_missingEntries.Count}");
 
             if (_missingEntries.Count > 0)
             {

--- a/Assets/UniLab/Tools/Editor/UnreferencedAssetFinder/UnreferencedAssetFinderWindow.cs
+++ b/Assets/UniLab/Tools/Editor/UnreferencedAssetFinder/UnreferencedAssetFinderWindow.cs
@@ -340,13 +340,15 @@ namespace UniLab.Tools.Editor.UnreferencedAssetFinder
         private void DrawResultHeader()
         {
             var totalSize = CalculateTotalFileSize(_unreferencedEntries);
-            EditorGUILayout.LabelField($"未参照アセット数: {_unreferencedEntries.Count}  合計サイズ: {FormatFileSize(totalSize)}");
+            // 未参照アセット数 / 合計サイズ
+            EditorGUILayout.LabelField($"Unreferenced Assets: {_unreferencedEntries.Count}  Total Size: {FormatFileSize(totalSize)}");
 
             if (_unreferencedEntries.Count > 0)
             {
                 var selectedCount = CountSelectedEntries(_unreferencedEntries);
                 var selectedSize = CalculateSelectedFileSize(_unreferencedEntries);
-                EditorGUILayout.LabelField($"選択中: {selectedCount} 件 ({FormatFileSize(selectedSize)})");
+                // 選択中の件数とサイズ
+                EditorGUILayout.LabelField($"Selected: {selectedCount} ({FormatFileSize(selectedSize)})");
             }
         }
 
@@ -394,7 +396,8 @@ namespace UniLab.Tools.Editor.UnreferencedAssetFinder
             var selectedCount = CountSelectedEntries(_unreferencedEntries);
             using (new EditorGUI.DisabledScope(selectedCount == 0))
             {
-                if (GUILayout.Button($"選択を削除 ({selectedCount})"))
+                // 選択を削除
+                if (GUILayout.Button($"Delete Selected ({selectedCount})"))
                 {
                     DeleteSelectedAssets();
                 }
@@ -622,7 +625,8 @@ namespace UniLab.Tools.Editor.UnreferencedAssetFinder
 
             if (!EditorUtility.DisplayDialog(
                     EditorToolLabels.Get(LabelKey.DeleteSelectedTitle),
-                    selectedCount + " 件 (" + FormatFileSize(selectedSize) + ") のアセットを完全に削除します。\nこの操作は元に戻せません。",
+                    // ○件 (サイズ) のアセットを完全に削除する。元に戻せない旨の警告。
+                    selectedCount + " assets (" + FormatFileSize(selectedSize) + ") will be permanently deleted.\nThis operation cannot be undone.",
                     EditorToolLabels.Get(LabelKey.Delete),
                     EditorToolLabels.Get(LabelKey.Cancel)))
             {
@@ -672,7 +676,8 @@ namespace UniLab.Tools.Editor.UnreferencedAssetFinder
             var isolationFolder = "Assets/_Unused/" + System.DateTime.Now.ToString("yyyy-MM-dd");
             if (!EditorUtility.DisplayDialog(
                     EditorToolLabels.Get(LabelKey.IsolateAssets),
-                    _unreferencedEntries.Count + " 件のアセットを " + isolationFolder + "/ に移動します",
+                    // ○件のアセットを隔離フォルダへ移動する
+                    _unreferencedEntries.Count + " assets will be moved to " + isolationFolder + "/",
                     EditorToolLabels.Get(LabelKey.Move),
                     EditorToolLabels.Get(LabelKey.Cancel)))
             {


### PR DESCRIPTION
## Summary

- Unity Editor が日本語フォントを描画できない問題への対応
- Editor 拡張の表示文字列と Debug.Log メッセージを英語化
- 日本語はコメントとして残置
- 17ファイル（Assets/UniLab/ 配下）の文字列内容のみ変更、挙動不変

## 対象範囲

- AssetVault: DebugEnvironmentSettingsEditor, DebugMenu, DuplicateAddressCollector, SetupSettings
- Localization: LocalizationAssetPostprocessor
- MasterData: MasterLocalViewer
- Persistence: UniLabPlayerPrefsEditorWindow
- Sample/Popup: PopupSampleBuilder, RewardPopup
- SceneManager: SceneNameEnumGenerator
- Tools: AssetReferenceFinder, ComponentUsageProfiler, MissingChecker, UnreferencedAssetFinder

🤖 Generated with [Claude Code](https://claude.com/claude-code)