### PR TITLE
fix: UniLab.asmdef に DOTween.Modules 参照を追加（questa 側修正の逆輸入）

### DIFF
--- a/Assets/UniLab/UniLab.asmdef
+++ b/Assets/UniLab/UniLab.asmdef
@@ -14,7 +14,8 @@
         "GUID:a8c40b3ab2ca249628aab9b762adccf8",
         "GUID:2ace7ebb826df10459d12b4f3c4a9407",
         "GUID:f51ebe6a0ceec4240a699833d6309b23",
-        "GUID:029c1c1b674aaae47a6841a0b89ad80e"
+        "GUID:029c1c1b674aaae47a6841a0b89ad80e",
+        "DOTween.Modules"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
questa-client の UniLab.asmdef には既に DOTween.Modules 参照があったが source 側に未反映だった。全 rsync 同期時の参照巻き戻りを防ぐため source に追従

🤖 Generated with [Claude Code](https://claude.com/claude-code)